### PR TITLE
Naive implementation of static guards

### DIFF
--- a/lib/emc/memcpy.c
+++ b/lib/emc/memcpy.c
@@ -2,6 +2,8 @@
 #include "export/string.h"
 #include <stdint.h>
 
+//! \todo Issue #9: this function get optimized out in certain cases
+//! if flto is enabled
 __attribute__((used))
 void * LIBC_FUNCTION(memcpy) (void *dst, const void *src, size_t cnt)
 {

--- a/lib/emc/memmove.c
+++ b/lib/emc/memmove.c
@@ -1,7 +1,5 @@
 #include "string.h"
 
-// Hack to avoid errors when using LTO
-__attribute__((used))
 void * LIBC_FUNCTION(memmove) (void *dst_void, const void *src_void, size_t length)
 {
     // Grabbed from newlib implementation

--- a/lib/emc/memset.c
+++ b/lib/emc/memset.c
@@ -3,8 +3,6 @@
 
 #include <stdint.h>
 
-// Hack to avoid errors when using LTO
-__attribute__((used))
 void * LIBC_FUNCTION(memset) (void *s, int c, size_t n)
 {
     uint8_t *dest = (uint8_t *) s;

--- a/lib/thread/freertos/utils.cpp
+++ b/lib/thread/freertos/utils.cpp
@@ -26,7 +26,7 @@ ecl::os::thread_handle ecl::os::this_thread::get_handle()
     TaskHandle_t handle = NULL;
 
     if (!ecl::in_isr()) {
-        ecl::disable_interrupts();
+        ecl::disable_irq();
         handle = reinterpret_cast< TaskHandle_t >(pxCurrentTCB);
     }
 

--- a/platform/stm32f4xx/export/platform/utils.hpp
+++ b/platform/stm32f4xx/export/platform/utils.hpp
@@ -13,12 +13,12 @@ bool in_isr();
 //!
 //! \brief Disables interrupt.
 //!
-void disable_interrupts();
+void disable_irq();
 
 //!
 //! \brief Enables interrupt.
 //!
-void enable_interrupts();
+void enable_irq();
 
 }
 

--- a/sys/sys.cpp
+++ b/sys/sys.cpp
@@ -27,11 +27,10 @@ void operator delete(void *, unsigned int)
 #endif
 
 // TODO: move this to toolchain-dependent module
-__attribute__((used))
 uintptr_t __stack_chk_guard = STACK_CHK_GUARD;
 
 // TODO: move this to toolchain-dependent module
-extern "C" __attribute__((noreturn)) __attribute__((used))
+extern "C" __attribute__((noreturn))
 void __stack_chk_fail(void)
 {
     ecl::cout << "Fail!!!" << ecl::endl;
@@ -39,7 +38,7 @@ void __stack_chk_fail(void)
 }
 
 // TODO: move this to toolchain-dependent module
-extern "C" __attribute__((used))
+extern "C"
 int atexit (void (*func)(void))
 {
     (void) func;
@@ -47,23 +46,23 @@ int atexit (void (*func)(void))
 }
 
 // TODO: move this to toolchain-dependent module
-extern "C" __attribute__((used))
+extern "C"
 int __cxa_guard_acquire(int *gv)
 {
     // Disable interrupts to prevent concurent access
     ecl::disable_irq();
 
-    if ((*gv) & 1) {
+    if (*gv == 1) {
         // Already locked
         return 0;
     } else {
-        *gv |= 1;
+        *gv = 1;
         return 1;
     }
 }
 
 // TODO: move this to toolchain-dependent module
-extern "C" __attribute__((used))
+extern "C"
 void __cxa_guard_release(int *gv)
 {
     (void) gv;
@@ -86,16 +85,16 @@ extern "C" void core_main(void)
     board_init();
     kernel_init();
 
-	extern uint32_t ___init_array_start;
-	extern uint32_t ___init_array_end;
+    extern uint32_t ___init_array_start;
+    extern uint32_t ___init_array_end;
 
-	for (uint32_t *p = &___init_array_start; p < &___init_array_end; ++p) {
-		// Iterator points to a memory which contains an address of a
-		// initialization function.
-		// Equivalent of:
-		// void (*fn)() = p;
-		// fn();
-		((void (*)()) *p)();
+    for (uint32_t *p = &___init_array_start; p < &___init_array_end; ++p) {
+        // Iterator points to a memory which contains an address of a
+        // initialization function.
+        // Equivalent of:
+        // void (*fn)() = p;
+        // fn();
+        ((void (*)()) *p)();
     }
 
     IRQ_manager::init();
@@ -119,7 +118,7 @@ namespace std
 // TODO: move this to toolchain-dependent module
 void __throw_bad_function_call()
 {
-	// TODO: abort
-	for (;;);
+    // TODO: abort
+    for (;;);
 }
 }

--- a/sys/sys.cpp
+++ b/sys/sys.cpp
@@ -2,6 +2,7 @@
 #include <cstddef>
 
 #include <platform/irq_manager.hpp>
+#include <platform/utils.hpp>
 #include <ecl/iostream.hpp>
 
 // TODO: move it somewhere
@@ -18,21 +19,56 @@ void operator delete(void *, unsigned int)
     for (;;);
 }
 
-
+// TODO: move this to toolchain-dependent module
 #if UINT32_MAX == UINTPTR_MAX
 #define STACK_CHK_GUARD 0xe2dee396
 #else
 #define STACK_CHK_GUARD 0x595e9fbd94fda766
 #endif
 
+// TODO: move this to toolchain-dependent module
 __attribute__((used))
 uintptr_t __stack_chk_guard = STACK_CHK_GUARD;
 
+// TODO: move this to toolchain-dependent module
 extern "C" __attribute__((noreturn)) __attribute__((used))
 void __stack_chk_fail(void)
 {
     ecl::cout << "Fail!!!" << ecl::endl;
     for(;;);
+}
+
+// TODO: move this to toolchain-dependent module
+extern "C" __attribute__((used))
+int atexit (void (*func)(void))
+{
+    (void) func;
+    return 0;
+}
+
+// TODO: move this to toolchain-dependent module
+extern "C" __attribute__((used))
+int __cxa_guard_acquire(int *gv)
+{
+    // Disable interrupts to prevent concurent access
+    ecl::disable_irq();
+
+    if ((*gv) & 1) {
+        // Already locked
+        return 0;
+    } else {
+        *gv |= 1;
+        return 1;
+    }
+}
+
+// TODO: move this to toolchain-dependent module
+extern "C" __attribute__((used))
+void __cxa_guard_release(int *gv)
+{
+    (void) gv;
+    // Object constructed. It is safe to enable interrupts.
+    ecl::enable_irq();
 }
 
 extern "C" void platform_init();
@@ -71,6 +107,7 @@ extern "C" void core_main(void)
     kernel_main();
 }
 
+// TODO: move this to toolchain-dependent module
 extern "C" void __cxa_pure_virtual()
 {
     // Abort
@@ -79,6 +116,7 @@ extern "C" void __cxa_pure_virtual()
 
 namespace std
 {
+// TODO: move this to toolchain-dependent module
 void __throw_bad_function_call()
 {
 	// TODO: abort

--- a/toolchains/arm-cm4-gnu.cmake
+++ b/toolchains/arm-cm4-gnu.cmake
@@ -53,16 +53,22 @@ set(CMAKE_CXX_FLAGS
 	CACHE STRING "C++ flags")
 
 # Release flags, optimization is on,
-set(CMAKE_C_FLAGS_RELEASE "-O3 -flto=4 -ffat-lto-objects " CACHE STRING "Debug C flags")
-set(CMAKE_CXX_FLAGS_RELEASE ${CMAKE_C_FLAGS_RELEASE})
+set(CMAKE_C_FLAGS_RELEASE "-O3 -flto=4 -ffat-lto-objects "
+	CACHE STRING "Release C flags")
+set(CMAKE_CXX_FLAGS_RELEASE ${CMAKE_C_FLAGS_RELEASE}
+	CACHE STRING "Release C++ flags")
 
 # Minimum size release flags, LTO and minimum size
-set(CMAKE_C_FLAGS_MINSIZEREL "-Os -flto=4 -ffat-lto-objects ")
-set(CMAKE_CXX_FLAGS_MINSIZEREL ${CMAKE_C_FLAGS_MINSIZEREL})
+set(CMAKE_C_FLAGS_MINSIZEREL "-Os -flto=4 -ffat-lto-objects "
+	CACHE STRING "Minsize C flags")
+set(CMAKE_CXX_FLAGS_MINSIZEREL ${CMAKE_C_FLAGS_MINSIZEREL}
+	CACHE STRING "Minsize C++ flags")
 
 # Debug mode, no LTO and maximum debug info
-set(CMAKE_C_FLAGS_DEBUG  "-O0 -g3 " CACHE STRING "Debug C flags")
-set(CMAKE_CXX_FLAGS_DEBUG ${CMAKE_C_FLAGS_DEBUG} CACHE STRING "Debug C++ flags")
+set(CMAKE_C_FLAGS_DEBUG  "-O0 -g3 "
+	CACHE STRING "Debug C flags")
+set(CMAKE_CXX_FLAGS_DEBUG ${CMAKE_C_FLAGS_DEBUG}
+	CACHE STRING "Debug C++ flags")
 
 set(CMAKE_OBJCOPY arm-none-eabi-objcopy CACHE STRING "Objcopy executable")
 


### PR DESCRIPTION
These methods are required to properly initialize static objects inside
a function call.

See also
http://kibergus.su/en/node/92
and
http://infocenter.arm.com/help/topic/com.arm.doc.ihi0043d/IHI0043D_rtabi.pdf
(Table 11, page 24)
