### PR TITLE
stm32f4 IRQ manager correct static members initialization

### DIFF
--- a/platform/stm32f4xx/CMakeLists.txt
+++ b/platform/stm32f4xx/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(stm32f4xx STATIC platform.cpp)
+add_library(stm32f4xx STATIC platform.cpp irq_manager.cpp)
 add_library(stm32f4xx_utils STATIC utils.c)
 
 target_include_directories(stm32f4xx PUBLIC export)
@@ -29,11 +29,11 @@ set(TARGET_PROCESSOR_ARCHITECTURE "arm_cm4" CACHE STRING "Processor arch")
 # corresponds to smaller logical priorities)
 
 message(STATUS "Checking [CONFIG_MAX_ISR_PRIORITY]...")
-if (NOT DEFINED CONFIG_MAX_ISR_PRIORITY)
+if(NOT DEFINED CONFIG_MAX_ISR_PRIORITY)
 	set(CONFIG_MAX_ISR_PRIORITY 0xff)
 	message(STATUS "CONFIG_MAX_ISR_PRIORITY not set,"
 		" using default value: ${CONFIG_MAX_ISR_PRIORITY}")
-endif ()
+endif()
 
 target_compile_definitions(
 	stm32f4xx

--- a/platform/stm32f4xx/irq_manager.cpp
+++ b/platform/stm32f4xx/irq_manager.cpp
@@ -1,0 +1,90 @@
+#include <platform/irq_manager.hpp>
+#include <new>
+
+IRQ_manager::handler_storage IRQ_manager::m_storage[IRQ_manager::irqs];
+
+
+void IRQ_manager::init()
+{
+    // Initialize storage
+    for (auto &h : m_storage) {
+        new (&h) handler_type{default_handler};
+    }
+
+    __enable_irq();
+}
+
+int IRQ_manager::subscribe(IRQn_t irqn, const std::function< void() > &handler)
+{
+    // TODO: error check
+    auto handlers = extract_handlers();
+
+    __disable_irq();
+
+    // Magic here.
+    // Logical priority of *any* user interrupt that use
+    // FreeRTOS API must not be greather than
+    // configMAX_SYSCALL_INTERRUPT_PRIORITY
+    NVIC_SetPriority(irqn, CONFIG_MAX_ISR_PRIORITY);
+    handlers[irqn] = handler;
+    __enable_irq();
+    return 0;
+}
+
+int IRQ_manager::unsubscribe(IRQn_t irqn)
+{
+    auto handlers = extract_handlers();
+    __disable_irq();
+    handlers[irqn] = default_handler;
+    __enable_irq();
+    return 0;
+}
+
+int IRQ_manager::mask(IRQn_t irqn)
+{
+    // TODO: error check
+    NVIC_DisableIRQ(irqn);
+    return 0;
+}
+
+int IRQ_manager::unmask(IRQn_t irqn)
+{
+    // TODO: error check
+    NVIC_EnableIRQ(irqn);
+    return 0;
+}
+
+int IRQ_manager::clear(IRQn_t irqn)
+{
+    // TODO: error check
+    NVIC_ClearPendingIRQ(static_cast< IRQn_t > (irqn));
+    return 0;
+}
+
+//------------------------------------------------------------------------------
+
+void IRQ_manager::isr()
+{
+    volatile int irqn;
+    auto handlers = extract_handlers();
+
+    asm volatile (
+                "mrs %0, ipsr" : "=r" (irqn)
+                );
+
+    // IPSR holds exception numbers starting from 0
+    // Valid IRQ number starts from -15
+    // See Cortex-M4 processors documentation
+    // http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0553a/CHDBIBGJ.html
+    irqn -= 16;
+
+    // TODO: Is it needed?
+    mask(static_cast< IRQn_t >(irqn));
+    handlers[irqn]();
+}
+
+void IRQ_manager::default_handler()
+{
+    __disable_irq();
+    for(;;);
+}

--- a/platform/stm32f4xx/platform.cpp
+++ b/platform/stm32f4xx/platform.cpp
@@ -3,14 +3,15 @@
 #include <misc.h>
 #include <core_cm4.h>
 
-// TODO: move it elsewhere
-std::function< void() > IRQ_manager::m_handlers[82];
-
 // TODO: decide if to make as a class member or not
 extern "C" __attribute__((used)) void platform_init()
 {
     // Required for FreeRTOS
+    // TODO: find better place for it
     NVIC_PriorityGroupConfig(NVIC_PriorityGroup_4);
+
+    // IRQ must be ready before anything else will start work
+    IRQ_manager::init();
 }
 
 namespace ecl

--- a/platform/stm32f4xx/startup/start.s
+++ b/platform/stm32f4xx/startup/start.s
@@ -64,7 +64,7 @@ clear_bss_end:
 			.long  PendSV_Handler              /* PendSV Handler               */
 			.long  SysTick_Handler             /* SysTick Handler              */
 			.rept  81							@ Repeat ASM statement
-			.long  _ZN11IRQ_manager3ISREv		@ All other handlers
+			.long  _ZN11IRQ_manager3isrEv		@ All other handlers
 			.endr
 			.align
 

--- a/sys/sys.cpp
+++ b/sys/sys.cpp
@@ -8,15 +8,15 @@
 // TODO: move it somewhere
 void operator delete(void *)
 {
-    // Abort - delete is forbidden
-    for (;;);
+    // TODO: call to abort routine
+    for(;;);
 }
 
 // TODO: move it somewhere
 void operator delete(void *, unsigned int)
 {
-    // Abort - delete is forbidden
-    for (;;);
+    // TODO: call to abort routine
+    for(;;);
 }
 
 // TODO: move this to toolchain-dependent module
@@ -33,7 +33,7 @@ uintptr_t __stack_chk_guard = STACK_CHK_GUARD;
 extern "C" __attribute__((noreturn))
 void __stack_chk_fail(void)
 {
-    ecl::cout << "Fail!!!" << ecl::endl;
+    // TODO: call to abort routine
     for(;;);
 }
 
@@ -97,11 +97,8 @@ extern "C" void core_main(void)
         ((void (*)()) *p)();
     }
 
-    IRQ_manager::init();
-
     // Due to undefined static init order, this initialization is placed here
     ecl::console_device.init();
-
 
     kernel_main();
 }


### PR DESCRIPTION
IRQ manager is a first entity that must be initialized in the system.
Placement new used inside init() methods helps to avoid issues
with static initialization order.
