### PR TITLE
stm32f4 IRQ manager correct static members initialization

### DIFF
--- a/platform/stm32f4xx/CMakeLists.txt
+++ b/platform/stm32f4xx/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(stm32f4xx STATIC platform.cpp)
+add_library(stm32f4xx STATIC platform.cpp irq_manager.cpp)
 add_library(stm32f4xx_utils STATIC utils.c)
 
 target_include_directories(stm32f4xx PUBLIC export)
@@ -29,11 +29,11 @@ set(TARGET_PROCESSOR_ARCHITECTURE "arm_cm4" CACHE STRING "Processor arch")
 # corresponds to smaller logical priorities)
 
 message(STATUS "Checking [CONFIG_MAX_ISR_PRIORITY]...")
-if (NOT DEFINED CONFIG_MAX_ISR_PRIORITY)
+if(NOT DEFINED CONFIG_MAX_ISR_PRIORITY)
 	set(CONFIG_MAX_ISR_PRIORITY 0xff)
 	message(STATUS "CONFIG_MAX_ISR_PRIORITY not set,"
 		" using default value: ${CONFIG_MAX_ISR_PRIORITY}")
-endif ()
+endif()
 
 target_compile_definitions(
 	stm32f4xx

--- a/platform/stm32f4xx/CMakeLists.txt
+++ b/platform/stm32f4xx/CMakeLists.txt
@@ -35,9 +35,19 @@ if(NOT DEFINED CONFIG_MAX_ISR_PRIORITY)
 		" using default value: ${CONFIG_MAX_ISR_PRIORITY}")
 endif()
 
-target_compile_definitions(
-	stm32f4xx
-	PUBLIC
+message(STATUS "Checking [CONFIG_PLATFORM_DEVICE]...")
+if (CONFIG_PLATFORM_DEVICE STREQUAL STM32F40_41xxx)
+	# Count of user-overridable interrupts.
+	# For this particular platform it doesn't include system exceptions,
+	# but only peripheral interrupts. Yet.
+	target_compile_definitions(stm32f4xx PUBLIC -DCONFIG_IRQ_COUNT=82)
+else()
+	# Additional implementation will be required to cover unsupported
+	# devices from stm32f4xx line.
+	message(FATAL_ERROR "Not supported device specified: ${CONFIG_PLATFORM_DEVICE}")
+endif()
+
+target_compile_definitions(stm32f4xx PUBLIC
 	-DCONFIG_MAX_ISR_PRIORITY=${CONFIG_MAX_ISR_PRIORITY})
 
 

--- a/platform/stm32f4xx/export/platform/irq_manager.hpp
+++ b/platform/stm32f4xx/export/platform/irq_manager.hpp
@@ -68,8 +68,6 @@ public:
     static int clear(IRQn_t irqn);
 
 private:
-    //! Total IRQ count.
-    static constexpr auto irqs = 82;
     using handler_storage =
     std::aligned_storage< sizeof(handler_type), alignof(handler_type) >::type;
 
@@ -80,7 +78,7 @@ private:
     static void default_handler();
 
     //! Storage for registered IRQ handlers.
-    static handler_storage m_storage[irqs];
+    static handler_storage m_storage[CONFIG_IRQ_COUNT];
 
     static constexpr auto extract_handlers()
     {

--- a/platform/stm32f4xx/export/platform/irq_manager.hpp
+++ b/platform/stm32f4xx/export/platform/irq_manager.hpp
@@ -1,3 +1,7 @@
+//!
+//! \file
+//! \brief stm32f4xx IRQ manager.
+//!
 #ifndef PLATFORM_IRQ_MANAGER_HPP
 #define PLATFORM_IRQ_MANAGER_HPP
 
@@ -5,6 +9,10 @@
 #include <core_cm4.h>
 
 #include <functional>
+#include <type_traits>
+
+// TODO: wrap whole module into the namespace
+// TODO: convert it to the snake_case
 
 using IRQn_t = IRQn_Type;
 
@@ -13,96 +21,72 @@ using IRQn_t = IRQn_Type;
 class IRQ_manager
 {
 public:
+    using handler_type = std::function< void() >;
+
     // TODO: setup VTOR?
     IRQ_manager() = delete;
     ~IRQ_manager() = delete;
 
-    static void init()
-    {
-        for (auto &h : m_handlers) {
-            h = default_handler;
-        }
+    //! Initializes IRQ manager and setups default handlers for every IRQ.
+    static void init();
 
-        __enable_irq();
-    }
+    //!
+    //! \brief Subscribes to given IRQ.
+    //! \param[in] irqn     Valid IRQ number.
+    //! \param[in] handler  New IRQ handler for given IRQ.
+    //! \retval 0 Success.
+    //!
+    static int subscribe(IRQn_t irqn, const handler_type &handler);
 
-    static int subscribe(IRQn_t IRQn, const std::function< void() > &handler)
-    {
-        // TODO: error check
+    //!
+    //! \brief Unsubscribes from given IRQ.
+    //! \detail Default handler will be used for given IRQ if this call succeed.
+    //! \param[in] irqn Valid IRQ number.
+    //! \retval 0 Success.
+    //!
+    static int unsubscribe(IRQn_t irqn);
 
-        __disable_irq();
+    //!
+    //! \brief Masks or disables given IRQ.
+    //! \param[in] irqn Valid IRQ number.
+    //! \retval 0 Success.
+    //!
+    static int mask(IRQn_t irqn);
 
-        // Magic here.
-        // Logical priority of *any* user interrupt that use
-        // FreeRTOS API must not be greather than
-        // configMAX_SYSCALL_INTERRUPT_PRIORITY
-        NVIC_SetPriority(IRQn, CONFIG_MAX_ISR_PRIORITY);
-        m_handlers[IRQn] = handler;
-        __enable_irq();
-        return 0;
-    }
+    //!
+    //! \brief Unmasks or enables given IRQ.
+    //! \param[in] irqn Valid IRQ number.
+    //! \retval 0 Success.
+    //!
+    static int unmask(IRQn_t irqn);
 
-    static int unsubscribe(IRQn_t IRQn)
-    {
-        __disable_irq();
-        m_handlers[IRQn] = default_handler;
-        __enable_irq();
-        return 0;
-    }
-
-    static int mask(IRQn_t IRQn)
-    {
-        // TODO: error check
-        NVIC_DisableIRQ(IRQn);
-        return 0;
-    }
-
-    static int unmask(IRQn_t IRQn)
-    {
-        // TODO: error check
-        NVIC_EnableIRQ(IRQn);
-        return 0;
-    }
-
-    static int clear(IRQn_t IRQn)
-    {
-        // TODO: error check
-        NVIC_ClearPendingIRQ(static_cast< IRQn_t > (IRQn));
-        return 0;
-    }
+    //!
+    //! \brief Clears pending interrupt of given IRQ.
+    //! \param[in] irqn Valid IRQ number.
+    //! \retval 0 Success.
+    //!
+    static int clear(IRQn_t irqn);
 
 private:
+    //! Total IRQ count.
+    static constexpr auto irqs = 82;
+    using handler_storage =
+    std::aligned_storage< sizeof(handler_type), alignof(handler_type) >::type;
+
     // Prevent optimizing out an ISR routine
-    __attribute__ ((used)) static void ISR()
+    __attribute__ ((used)) void isr();
+
+    //! Default iRQ handler. Terminates execution if called.
+    static void default_handler();
+
+    //! Storage for registered IRQ handlers.
+    static handler_storage m_storage[irqs];
+
+    static constexpr auto extract_handlers()
     {
-        volatile int IRQn;
-
-        asm volatile (
-                    "mrs %0, ipsr" : "=r" (IRQn)
-                    );
-
-        // IPSR holds exception numbers starting from 0
-        // Valid IRQ number starts from -15
-        // See Cortex-M4 processors documentation
-        // http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0553a/CHDBIBGJ.html
-        IRQn -= 16;
-
-        // TODO: Is it needed?
-        mask(static_cast< IRQn_t >(IRQn));
-        m_handlers[IRQn]();
+        return reinterpret_cast< handler_type* >(&m_storage);
     }
-
-    static void default_handler()
-    {
-        __disable_irq();
-        for(;;);
-    }
-
-    // Registered IRQ handlers
-    // TODO: magic numbers
-    static std::function< void() > m_handlers[82];
 };
-
 
 
 #endif

--- a/platform/stm32f4xx/irq_manager.cpp
+++ b/platform/stm32f4xx/irq_manager.cpp
@@ -1,0 +1,90 @@
+#include <platform/irq_manager.hpp>
+#include <new>
+
+IRQ_manager::handler_storage IRQ_manager::m_storage[IRQ_manager::irqs];
+
+
+void IRQ_manager::init()
+{
+    // Initialize storage
+    for (auto &h : m_storage) {
+        new (&h) handler_type{default_handler};
+    }
+
+    __enable_irq();
+}
+
+int IRQ_manager::subscribe(IRQn_t irqn, const std::function< void() > &handler)
+{
+    // TODO: error check
+    auto handlers = extract_handlers();
+
+    __disable_irq();
+
+    // Magic here.
+    // Logical priority of *any* user interrupt that use
+    // FreeRTOS API must not be greather than
+    // configMAX_SYSCALL_INTERRUPT_PRIORITY
+    NVIC_SetPriority(irqn, CONFIG_MAX_ISR_PRIORITY);
+    handlers[irqn] = handler;
+    __enable_irq();
+    return 0;
+}
+
+int IRQ_manager::unsubscribe(IRQn_t irqn)
+{
+    auto handlers = extract_handlers();
+    __disable_irq();
+    handlers[irqn] = default_handler;
+    __enable_irq();
+    return 0;
+}
+
+int IRQ_manager::mask(IRQn_t irqn)
+{
+    // TODO: error check
+    NVIC_DisableIRQ(irqn);
+    return 0;
+}
+
+int IRQ_manager::unmask(IRQn_t irqn)
+{
+    // TODO: error check
+    NVIC_EnableIRQ(irqn);
+    return 0;
+}
+
+int IRQ_manager::clear(IRQn_t irqn)
+{
+    // TODO: error check
+    NVIC_ClearPendingIRQ(static_cast< IRQn_t > (irqn));
+    return 0;
+}
+
+//------------------------------------------------------------------------------
+
+void IRQ_manager::isr()
+{
+    volatile int irqn;
+    auto handlers = extract_handlers();
+
+    asm volatile (
+                "mrs %0, ipsr" : "=r" (irqn)
+                );
+
+    // IPSR holds exception numbers starting from 0
+    // Valid IRQ number starts from -15
+    // See Cortex-M4 processors documentation
+    // http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0553a/CHDBIBGJ.html
+    irqn -= 16;
+
+    // TODO: Is it needed?
+    mask(static_cast< IRQn_t >(irqn));
+    handlers[irqn]();
+}
+
+void IRQ_manager::default_handler()
+{
+    __disable_irq();
+    for(;;);
+}

--- a/platform/stm32f4xx/irq_manager.cpp
+++ b/platform/stm32f4xx/irq_manager.cpp
@@ -1,7 +1,7 @@
 #include <platform/irq_manager.hpp>
 #include <new>
 
-IRQ_manager::handler_storage IRQ_manager::m_storage[IRQ_manager::irqs];
+IRQ_manager::handler_storage IRQ_manager::m_storage[CONFIG_IRQ_COUNT];
 
 
 void IRQ_manager::init()
@@ -16,7 +16,11 @@ void IRQ_manager::init()
 
 int IRQ_manager::subscribe(IRQn_t irqn, const std::function< void() > &handler)
 {
-    // TODO: error check
+    // TODO: Use platform assert when it will be ready
+    if (irqn < 0) {
+        return -1;
+    }
+
     auto handlers = extract_handlers();
 
     __disable_irq();
@@ -33,6 +37,11 @@ int IRQ_manager::subscribe(IRQn_t irqn, const std::function< void() > &handler)
 
 int IRQ_manager::unsubscribe(IRQn_t irqn)
 {
+    // TODO: Use platform assert when it will be ready
+    if (irqn < 0) {
+        return -1;
+    }
+
     auto handlers = extract_handlers();
     __disable_irq();
     handlers[irqn] = default_handler;
@@ -42,13 +51,22 @@ int IRQ_manager::unsubscribe(IRQn_t irqn)
 
 int IRQ_manager::mask(IRQn_t irqn)
 {
-    // TODO: error check
+    // TODO: Use platform assert when it will be ready
+    if (irqn < 0) {
+        return -1;
+    }
+
     NVIC_DisableIRQ(irqn);
     return 0;
 }
 
 int IRQ_manager::unmask(IRQn_t irqn)
 {
+    // TODO: Use platform assert when it will be ready
+    if (irqn < 0) {
+        return -1;
+    }
+
     // TODO: error check
     NVIC_EnableIRQ(irqn);
     return 0;
@@ -56,6 +74,11 @@ int IRQ_manager::unmask(IRQn_t irqn)
 
 int IRQ_manager::clear(IRQn_t irqn)
 {
+    // TODO: Use platform assert when it will be ready
+    if (irqn < 0) {
+        return -1;
+    }
+
     // TODO: error check
     NVIC_ClearPendingIRQ(static_cast< IRQn_t > (irqn));
     return 0;

--- a/platform/stm32f4xx/platform.cpp
+++ b/platform/stm32f4xx/platform.cpp
@@ -3,14 +3,15 @@
 #include <misc.h>
 #include <core_cm4.h>
 
-// TODO: move it elsewhere
-std::function< void() > IRQ_manager::m_handlers[82];
-
 // TODO: decide if to make as a class member or not
 extern "C" __attribute__((used)) void platform_init()
 {
     // Required for FreeRTOS
+    // TODO: find better place for it
     NVIC_PriorityGroupConfig(NVIC_PriorityGroup_4);
+
+    // IRQ must be ready before anything else will start work
+    IRQ_manager::init();
 }
 
 namespace ecl

--- a/platform/stm32f4xx/startup/start.s
+++ b/platform/stm32f4xx/startup/start.s
@@ -64,7 +64,7 @@ clear_bss_end:
 			.long  PendSV_Handler              /* PendSV Handler               */
 			.long  SysTick_Handler             /* SysTick Handler              */
 			.rept  81							@ Repeat ASM statement
-			.long  _ZN11IRQ_manager3ISREv		@ All other handlers
+			.long  _ZN11IRQ_manager3isrEv		@ All other handlers
 			.endr
 			.align
 

--- a/sys/sys.cpp
+++ b/sys/sys.cpp
@@ -8,15 +8,15 @@
 // TODO: move it somewhere
 void operator delete(void *)
 {
-    // Abort - delete is forbidden
-    for (;;);
+    // TODO: call to abort routine
+    for(;;);
 }
 
 // TODO: move it somewhere
 void operator delete(void *, unsigned int)
 {
-    // Abort - delete is forbidden
-    for (;;);
+    // TODO: call to abort routine
+    for(;;);
 }
 
 // TODO: move this to toolchain-dependent module
@@ -33,7 +33,7 @@ uintptr_t __stack_chk_guard = STACK_CHK_GUARD;
 extern "C" __attribute__((noreturn))
 void __stack_chk_fail(void)
 {
-    ecl::cout << "Fail!!!" << ecl::endl;
+    // TODO: call to abort routine
     for(;;);
 }
 
@@ -97,11 +97,8 @@ extern "C" void core_main(void)
         ((void (*)()) *p)();
     }
 
-    IRQ_manager::init();
-
     // Due to undefined static init order, this initialization is placed here
     ecl::console_device.init();
-
 
     kernel_main();
 }


### PR DESCRIPTION
IRQ manager is a first entity that must be initialized in the system.
Placement new used inside init() methods helps to avoid issues
with static initialization order.
