### PR TITLE
Nifty counter implementation for ecl streams

### DIFF
--- a/kernel/freertos/CMakeLists.txt
+++ b/kernel/freertos/CMakeLists.txt
@@ -21,7 +21,6 @@ endif()
 set(SRC_DIR freertos/FreeRTOS/Source/)
 
 # Obtain some processor info
-#get_property(TARGET_ARCH GLOBAL PROPERTY TARGET_PROCESSOR_ARCHITECTURE)
 set(TARGET_ARCH ${TARGET_PROCESSOR_ARCHITECTURE})
 
 # Compiler-dependent paths.

--- a/lib/cpp/export/ecl/iostream.hpp
+++ b/lib/cpp/export/ecl/iostream.hpp
@@ -57,13 +57,23 @@ private:
     // for this class, must be added to this class
 };
 
+//!
+//! \brief Static initializer for every translation unit.
+//! \details [Nifty counter idiom](https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Nifty_Counter)
+//! is used here.
+//!
+static struct iostream_initializer
+{
+    iostream_initializer();
+    ~iostream_initializer();
+} stream_initializer;
 
 // Standard streams, defined elsewhere
 // These streams rely on specific driver, which name should be
 // the same accross all targets
-extern istream< console_driver > cin;
-extern ostream< console_driver > cout;
-extern ostream< console_driver > cerr;
+extern istream< console_driver > &cin;
+extern ostream< console_driver > &cout;
+extern ostream< console_driver > &cerr;
 
 
 //------------------------------------------------------------------------------

--- a/lib/cpp/streams.cpp
+++ b/lib/cpp/streams.cpp
@@ -1,15 +1,77 @@
+//!
+//! \file
+//! \brief Main iostream module.
+//! Nifty counter idiom is used here.
+//! See [wiki article about that](https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Nifty_Counter)
+//!
+
 #include <ecl/iostream.hpp>
+
+#include <new>         // placement new
+#include <type_traits> // aligned_storage
 
 namespace ecl {
 
+// Useful aliases
+using cin_type  = istream< console_driver >;
+using cout_type = ostream< console_driver >;
+using cerr_type = ostream< console_driver >;
+
+//! Tracks initialization and destruction.
+static int nifty_counter;
+
+//! Memory for the console device driver
+static typename std::aligned_storage< sizeof(console_driver), alignof(console_driver) >::type
+  console_obj_buf;
+
+//! Memory for the cin object
+static typename std::aligned_storage< sizeof(cin_type), alignof(cin_type) >::type
+  cin_obj_buf;
+
+//! Memory for the cout object
+static typename std::aligned_storage< sizeof(cout_type), alignof(cout_type) >::type
+  cout_obj_buf;
+
+//! Memory for the cerr object
+static typename std::aligned_storage< sizeof(cerr_type), alignof(cerr_type) >::type
+  cerr_obj_buf;
+
 // TODO: think about extending of console devices to cover
-// case when there are different drivers for cin, count and cerr streams.
-typename istream< console_driver >::device_type console_device;
+// a case when different drivers for cin, count and cerr streams must be used.
+typename istream< console_driver >::device_type &console_device
+= reinterpret_cast< console_driver& >(console_obj_buf);
 
-// TODO: avoid this somehow.
-// See https://isocpp.org/wiki/faq/ctors#static-init-order
+cin_type  &cin  = reinterpret_cast< cin_type& >(cin_obj_buf);
+cout_type &cout = reinterpret_cast< cout_type& >(cout_obj_buf);
+cerr_type &cerr = reinterpret_cast< cerr_type& >(cerr_obj_buf);
 
-istream< console_driver > cin{&console_device};
-ostream< console_driver > cout{&console_device};
-ostream< console_driver > cerr{&console_device};
+iostream_initializer::iostream_initializer()
+{
+    if (!nifty_counter++) {
+        // Driver must be ready before streams will use it.
+        new (&console_obj_buf) console_driver{};
+
+        console_device.init();
+
+        new (&cin_obj_buf)   cin_type{&console_device};
+        new (&cout_obj_buf)  cout_type{&console_device};
+        new (&cerr_obj_buf)  cerr_type{&console_device};
+
+        // Streams could be used direclty only after kernel_main() call
+        // in sys.cpp module.
+        // This is unwanted limitation.
+        // TODO: resolve it.
+    }
+}
+
+iostream_initializer::~iostream_initializer()
+{
+    if (!--nifty_counter) {
+        cerr.~cerr_type();
+        cout.~cout_type();
+        cin.~cin_type();
+        console_device.~console_driver();
+    }
+}
+
 }

--- a/sys/CMakeLists.txt
+++ b/sys/CMakeLists.txt
@@ -7,8 +7,6 @@ add_library(sys STATIC sys.cpp)
 target_link_libraries(sys ${CONFIG_PROJECT_LIB})
 # IRQ manager is required that residing in platform
 target_link_libraries(sys ${PLATFORM_NAME})
-# Requires libcpp to initialize streams
-target_link_libraries(sys libcpp)
 
 # A special initialization is required if kernel is present
 if (DEFINED CONFIG_OS)

--- a/sys/sys.cpp
+++ b/sys/sys.cpp
@@ -3,7 +3,6 @@
 
 #include <platform/irq_manager.hpp>
 #include <platform/utils.hpp>
-#include <ecl/iostream.hpp>
 
 // TODO: move it somewhere
 void operator delete(void *)
@@ -75,10 +74,6 @@ extern "C" void board_init();
 extern "C" void kernel_init();
 extern "C" void kernel_main();
 
-namespace ecl {
-extern typename istream< console_driver >::device_type console_device;
-}
-
 extern "C" void core_main(void)
 {
     platform_init();
@@ -96,9 +91,6 @@ extern "C" void core_main(void)
         // fn();
         ((void (*)()) *p)();
     }
-
-    // Due to undefined static init order, this initialization is placed here
-    ecl::console_device.init();
 
     kernel_main();
 }


### PR DESCRIPTION
One of correct way to guarantee the initialization order of the console
stream is to use nifty counters.
No more talks, see: https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Nifty_Counter
