### PR TITLE
The bus: #36 Basic support of running xfer() during IRQ

### DIFF
--- a/dev/bus/export/dev/bus.hpp
+++ b/dev/bus/export/dev/bus.hpp
@@ -20,12 +20,11 @@
 namespace ecl
 {
 
-//! \brief Generic bus interface.
-//!
-//! The generic bus is useful adapter, that allows to:
-//! \li Encapsulate locking policy when multithreded environment is used.
-//! \li Hide differences between full-duplex and half-duplex busses.
-//! \li Define and simplify platform-level bus interface
+//! Generic bus interface.
+//! \details The generic bus is useful adapter, that allows to:
+//! - Encapsulate locking policy when multithreded environment is used.
+//! - Hide differences between full-duplex and half-duplex busses.
+//! - Define and simplify platform-level bus interface
 //! \tparam PBus Platform-level bus driver (I2C, SPI, etc.)
 //!
 //! This class uses one of methods to prevent “static initialization order
@@ -40,23 +39,22 @@ public:
     generic_bus() = delete;
     ~generic_bus() = delete;
 
-    //! \brief Inits a bus.
-    //! Lazy initialization. Inits an underlying platform bus.
+    //! Inits a bus.
+    //! \details Lazy initialization. Inits an underlying platform bus.
     //! \todo introduce init counter.
     //! \return Status of operation.
     //!
     static err init();
 
-    //! \brief De-inits a bus.
+    //! De-inits a bus.
     //! \pre Bus is initied.
     //! \todo use init counter to measure how many users are inited this bus.
     //! \return Status of operation.
     //!
     static err deinit();
 
-    //! \brief Locks a bus.
-    //!
-    //! Any further operations can be executed after call to this function.
+    //! Locks a bus.
+    //! \details Any further operations can be executed after call to this function.
     //! If previous async xfer is in progress then current thread will be blocked
     //! until its finish.
     //! \pre    Bus is inited successfully.
@@ -65,9 +63,8 @@ public:
     //!
     static void lock();
 
-    //! \brief Unlocks a bus.
-    //!
-    //! Any operations beside lock() is not permitted after this method finishes.
+    //! Unlocks a bus.
+    //! \details Any operations beside lock() is not permitted after this method finishes.
     //! \par Side effects:
     //! \li In block mode all buffers provided with set_buffers() will be discarded
     //! \li In async mode if operation still ongoing, buffers will be discarded
@@ -79,9 +76,8 @@ public:
     //!
     static void unlock();
 
-    //! \brief Sets RX and TX buffers and their sizes.
-    //!
-    //! If only TX or RX transaction required, then only one buffer must
+    //! Sets RX and TX buffers and their sizes.
+    //! \details If only TX or RX transaction required, then only one buffer must
     //! be passed. All effects from calls to set_buffers() will be discarded.
     //! \par Side effects:
     //! \li Bus will remember all buffers, until unlock() or set_buffers()
@@ -99,18 +95,17 @@ public:
     //!
     static err set_buffers(const uint8_t *tx, uint8_t *rx, size_t size);
 
-    //! \brief Sets TX buffer size and fills it with given byte.
-    //!
-    //! This will instruct a platform bus to send a byte given number of times.
-    //! It is implementation defined how bus is chunks in which data is sent.
-    //! If possible, platform bus will just send single-byte buffer via DMA.
-    //!
-    //! In half-duplex case RX will not be performed. If platform bus is in
-    //! full duplex mode then RX will be executed but RX data will be ignored.
-    //!
-    //! \par Side effects:
-    //! \li Bus will remember a buffer, until unlock() or set_buffers()
-    //!     will be called.
+    //! Sets TX buffer size and fills it with given byte.
+    //! \details This will instruct a platform bus to send a byte given number
+    //! of times. It is implementation defined how platform-level bus handles
+    //! incoming data, e.g. it can be splitted into chunks when sending to
+    //! the destination, if platform bus protocol allows such thing.
+    //! \details In half-duplex case RX will not be performed. If platform bus
+    //! is in full duplex mode then RX will be executed but RX data will be
+    //! ignored.
+    //! \par Side effects
+    //! - Bus will remember a buffer, until unlock() or set_buffers() will
+    //!   be called.
     //! \pre       Bus is locked.
     //! \post      Bus is ready to execute xfer.
     //! \param[in] size         Size of filled buffer.
@@ -120,10 +115,10 @@ public:
     //!
     static err set_buffers(size_t size, uint8_t fill_byte = 0xff);
 
-    //! \brief Performs xfer in blocking mode using buffers set previously.
-    //!
-    //! If underlying bus works in half-duplex mode then first tx transaction
-    //! will occur and then rx.
+    //! Performs xfer in blocking mode using buffers set previously.
+    //! \details If underlying bus works in half-duplex mode then first
+    //! tx transaction will occur and then rx. Any deffered xfer will be
+    //! canceled in result of this call and simple, blocking xfer will proceed.
     //! \warning Method uses a semaphore to wait for a bus event (most likely
     //! an IRQ event). It means that in bare-metal environment,
     //! without RTOS it is implemented as simple spin-lock. Likely that
@@ -140,45 +135,70 @@ public:
     //!
     static err xfer(size_t *sent = nullptr, size_t *received = nullptr);
 
-    //! \brief Performs xfer in async mode using buffers set previously.
-    //!
-    //! If underlying bus works in half-duplex mode then first tx transaction
-    //! will occur and then rx.
-    //! When xfer will be done, given handler will be invoked with a
-    //! type of an event.
+    //! Performs xfer in async mode using buffers set previously.
+    //! \details If underlying bus works in half-duplex mode then first
+    //! tx transaction will occur and then rx. When xfer will be done, given
+    //! handler will be invoked with a type of an event.
+    //! \details It is also possible to postpone xfer, i.e. "defer" it
+    //! and then trigger at will using xfer_trigger() method. See xfer_trigger()
+    //! for more defails. Any previous defered xfer will be canceled in result
+    //! of this call.
     //! \warning Event handler most likely will be executed in ISR context.
     //! Pay attention to it. Do not block inside of it or do anything else that
     //! can break ISR or impose high interrupt latency.
-    //! \note Errors that occur after transaction has started are reported via
-    //! user-supplied handler. \sa PBus::event
     //! \note Bytes transferred are reported via user-supplied handler
     //! per each channel (tx, rx) separately.
+    //! \note Errors that occur after transaction has started are reported via
+    //! user-supplied handler.
+    //! \sa PBus::event
     //! \pre       Bus is locked and buffers are set.
     //! \post      Bus remains in the same state.
-    //! \param[in] handler      User-supplied event handler.
-    //! \retval    err::ok      Data is sent successfully.
-    //! \retval    err::busy    Device is still executing async xfer.
-    //! \retval    err          Any other error that can occur in platform bus.
+    //! \param[in] handler   User-supplied event handler.
+    //! \param[in] type      Type of xfer. Possible values are:
+    //!                      - async_type::immediate:
+    //!                      xfer will be started as soon as possible.
+    //!                      - async_type::deferred:
+    //!                      xfer will be postponed until xfer_trigger() call
+    //! \retval    err::ok   Data is sent successfully.
+    //! \retval    err::busy Device is still executing async xfer.
+    //! \retval    err       Any other error that can occur in platform bus.
     //!
-    static err xfer(const bus_handler &handler);
+    static err xfer(const bus_handler &handler, async_type type = async_type::immediate);
 
-    //! \brief Returns a reference to underlying platform bus.
+    //! Triggers continued or deffered xfer in async mode.
+    //! \details Method is capable of triggering two types of xfers:
+    //!  - Continuated:
+    //!    triggers a new xfer with the same buffers and handlers that were used
+    //!    during last xfer.
+    //!  - Deffered:
+    //!    triggers the scheduled xfer, such that was defer using xfer() call.
+    //! \details This method is a kind of a important optimization trick. It is
+    //! possible to call it from IRQ context. It uses buffers and handlers
+    //! from previous xfers, so there is no overhead for unneeded assignments.
+    //! \pre       Bus is locked, buffers are set and async xfer is either
+    //!            defered or executed.
+    //! \post      Xfer is ongoing.
+    //!
+    static err trigger_xfer();
+
+    //! Returns a reference to underlying platform bus.
     //! \details   This allows to perform specific for underlying bus operations.
     //! \retval    PBus&    Reference to underlying platform bus.
+    //!
     static PBus& platform_handle();
 
 private:
     //! Convinient alias.
     using atomic_flag   = std::atomic_flag;
 
-    //! \brief Event handler dedicated to the platform bus.
+    //! Event handler dedicated to the platform bus.
     //! \param[in] ch     Channel (rx or tx) where the event occurred.
     //! \param[in] type   Type of event occurred.
     //! \param[in] total  Total amount of bytes transferred within given channel.
     //!
     static void platform_handler(bus_channel ch, bus_event type, size_t total);
 
-    //! \brief Checks if bus is busy transferring data at this moment or not.
+    //! Checks if bus is busy transferring data at this moment or not.
     //! \retval true Bus is busy.
     //!
     static bool bus_is_busy();
@@ -291,21 +311,20 @@ void generic_bus< PBus >::unlock()
     // rather than an error check.
     m_state &= ~(bus_locked);
 
-    // Do cleanup in block mode - bus is guaranteed to finish all transaction
-    // prior to unlock() call
     if (m_state & async_mode) {
         if (m_state & xfer_served) {
-
             // Cleanup routine is a critical section and both platform_handler()
-            // and unlock() routine can try to access it concurently.
+            // and unlock() routine can try to access it concurrently.
             // Wrapping this part with mutexes must be avoided
             // because platform_handler() will likely be executed in ISR context.
-            // Using atomics is most convinient solution.
+            // Using atomics is most convenient solution.
             if (!m_cleaned.test_and_set()) {
                 cleanup();
             }
         }
     } else {
+        // Do cleanup in block mode - bus is guaranteed to finish all transaction
+        // prior to unlock() call
         cleanup();
     }
 
@@ -378,7 +397,7 @@ ecl::err generic_bus< PBus >::xfer(size_t *sent, size_t *received)
 
     auto rc = platform_handle().do_xfer();
 
-    if (!is_error(rc)) {
+    if (is_ok(rc)) {
         sem().wait();
 
         // Errors can occur after transaction start, check this
@@ -387,7 +406,7 @@ ecl::err generic_bus< PBus >::xfer(size_t *sent, size_t *received)
         }
 
         // Return amount of bytes written and/or read.
-        // Even if error occurred, some data was possibly transffered.
+        // Even if error occurred, some data was possibly transferred.
 
         if (received) {
             *received = m_received;
@@ -398,7 +417,7 @@ ecl::err generic_bus< PBus >::xfer(size_t *sent, size_t *received)
 
     } else {
         // Deem that xfer virtually occurs in blocking mode and thus
-        // momentally served in case of error.
+        // momentarily served in case of error.
         m_state |= xfer_served;
     }
 
@@ -406,20 +425,34 @@ ecl::err generic_bus< PBus >::xfer(size_t *sent, size_t *received)
 }
 
 template< class PBus >
-ecl::err generic_bus< PBus >::xfer(const bus_handler &handler)
+ecl::err generic_bus< PBus >::xfer(const bus_handler &handler, async_type type)
 {
     // If bus is not locked then pre-conditions are violated
     // and it is clearly a sign of a bug
     ecl_assert(m_state & bus_locked);
 
-    // Clears IRQ flag as well.
     if (bus_is_busy()) {
         return err::busy;
     }
 
+    cb() = handler;
+
+    if (type == async_type::deferred) {
+        // Xfer will be executed when upon user's will.
+        return err::ok;
+    }
+
+    return trigger_xfer();
+}
+
+template< class PBus >
+ecl::err generic_bus< PBus >::trigger_xfer()
+{
+    ecl_assert(m_state & bus_locked);
+    ecl_assert(!bus_is_busy()); // Violating of pre-conditions
+
     // Async mode xfer is provided
     m_state |= async_mode;
-    cb() = handler;
 
     m_cleaned.clear();
 
@@ -427,7 +460,10 @@ ecl::err generic_bus< PBus >::xfer(const bus_handler &handler)
 
     if (is_error(rc)) {
         // Deem that xfer virtually occurs in blocking mode and thus
-        // momentally served in case of error.
+        // momentarily served in case of error.
+        // No need to signal semaphore here, since any pending client
+        // (i.e. other thread) is blocked waiting on mutex and do not yet
+        // discovered xfer mode. See lock() for details.
         m_state |= xfer_served;
         m_state &= ~(async_mode);
     } else {
@@ -452,6 +488,8 @@ void generic_bus< PBus >::platform_handler(bus_channel ch, bus_event type, size_
 
     if (last_event) {
         // Spurious events are not allowed
+        // TODO #27: platform assert here is required since this routine
+        // is likely will be executed in IRQ context
         ecl_assert(!(m_state & xfer_served));
 
         m_state |= xfer_served;
@@ -460,8 +498,17 @@ void generic_bus< PBus >::platform_handler(bus_channel ch, bus_event type, size_
     if (m_state & async_mode) {
         cb()(ch, type, total);
 
-        // Bus unlocked, it is time to check if bus cleaned.
+        // User is granted to continue xfer when handling the last bus event,
+        // thus xfer_served flag will be cleared. It is called 'continuous xfer'.
+        // During continuous xfers any client waiting for a bus lock will remain
+        // blocked until current bus client will finish all its xfers.
+        // TODO: assert that user start new xfer _only_ during last event handling.
+        // TODO #27: platform assert here is required since this routine
+        // is likely will be executed in IRQ context
+        last_event = (m_state | xfer_served);
+
         if (last_event && !(m_state & bus_locked)) {
+            // Bus is unlocked, it is time to check if bus cleaned.
 
             // It is possible that bus_handler() is executed in thread context
             // rather in ISR context. This means that context switch can occur
@@ -476,7 +523,7 @@ void generic_bus< PBus >::platform_handler(bus_channel ch, bus_event type, size_
             }
         }
     } else {
-        // In blocking mode a bus is responsible for bytes counting
+        // In blocking mode a bus is responsible for bytes counting.
         if (ch == bus_channel::tx) {
             m_sent = total;
         } else if (ch == bus_channel::rx) {
@@ -495,8 +542,8 @@ void generic_bus< PBus >::platform_handler(bus_channel ch, bus_event type, size_
 template< class PBus >
 bool generic_bus< PBus >::bus_is_busy()
 {
-    // Asynchronius operation still in progress.
-    return (m_state & async_mode);
+    // Asynchronous operation still in progress.
+    return (m_state & async_mode) && !(m_state & xfer_served);
 }
 
 template< class PBus >

--- a/platform/common/bus/export/platform/common/bus.hpp
+++ b/platform/common/bus/export/platform/common/bus.hpp
@@ -15,9 +15,7 @@
 namespace ecl
 {
 
-//!
-//! \brief Channels of a bus.
-//!
+//! Channels of a bus.
 enum class bus_channel
 {
     rx,         //!< Receive channel.
@@ -25,14 +23,19 @@ enum class bus_channel
     meta,       //!< Meta-channel.
 };
 
-//!
-//! \brief Various events.
-//!
+//! Various events.
 enum class bus_event
 {
     ht,         //!< Half transfer event.
     tc,         //!< Transfer complete event.
     err,        //!< Error event.
+};
+
+//! Defines async xfer types.
+enum class async_type
+{
+    deferred,   //!< Xfer going to be deferred until user asks.
+    immediate,  //!< Xfer will be executed as soon as possible.
 };
 
 //!


### PR DESCRIPTION
Splitting the async xfer into two parts helps avoid unnecessary
overhead with setuping buffers and handlers.

Continuation xfer support included.
