### PR TITLE
Fix Nix shell command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The installation guide could be found
 
 After `nix` installation, run:
 ```bash
-nix-shell core --pure
+nix-shell --pure
 ...
 ```
 


### PR DESCRIPTION
Seems that Nix configuration was previously in the `core` directory, but
now it's in the root one, so plain `nix-shell` is enough to launch the
shell (and the previous command doesn't work).
