### PR TITLE
Workaround corrupted greeting when using bypass console

### DIFF
--- a/platform/tm4c/export/platform/execution.h
+++ b/platform/tm4c/export/platform/execution.h
@@ -17,7 +17,7 @@ static inline void ecl_spin_wait(uint32_t ms)
 }
 
 
-static void ecl_abort()
+static inline void ecl_abort()
 {
     for(;;);
 }

--- a/sys/sys.cpp
+++ b/sys/sys.cpp
@@ -7,6 +7,7 @@
 
 #include <common/irq.hpp>
 #include <platform/console.hpp>
+#include <platform/execution.h>
 
 // TODO: move it somewhere
 void operator delete(void *)
@@ -85,6 +86,14 @@ extern "C" void core_main()
 {
     platform_init();
     board_init();
+
+#ifdef CONFIG_BYPASS_CONSOLE_ENABLED
+	// Dirty hack to make sure pin configuration is established before
+	// bypass console will be used.
+	// It should be fixed by configuring console GPIO directly in the platform,
+    // not in the user's `board_init()` routine. See issue #151.
+    ecl_spin_wait(50);
+#endif
     kernel_main();
 }
 


### PR DESCRIPTION
Small delay added as workaround. Issue #151 must fix corruption fully.
