### PR TITLE
theCore: fix platform selection based on cross-compilation facts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,19 +17,29 @@ include(Findcppcheck)
 include(CppcheckTargets)
 
 # TODO: add same configuration mechanism for choosing right kernel
+
 message(STATUS "Checking [CONFIG_PLATFORM]...")
-if(NOT DEFINED CONFIG_PLATFORM)
-    message(STATUS "CONFIG_PLATFORM is not set, defaulting to 'host'...")
-    set(PLATFORM_NAME host)
+
+if(NOT CMAKE_CROSSCOMPILING)
+    if(DEFINED CONFIG_PLATFORM)
+        if (NOT CONFIG_PLATFORM STREQUAL "host")
+            message(FATAL_ERROR "CONFIG_PLATFORM must be set to 'host' if not cross-compiling")
+        endif()
+    else()
+        # It is fine to omit platform name if not cross-compiling
+        message(STATUS "CONFIG_PLATFORM not set, defauluting to 'host'...")
+        set(CONFIG_PLATFORM "host")
+    endif()
 else()
-    message(STATUS "Platform will be used: ${CONFIG_PLATFORM}")
-    set(PLATFORM_NAME ${CONFIG_PLATFORM}) # For convinience
+    # When cross-compiling, platform must be set explicitly.
+    if(NOT DEFINED CONFIG_PLATFORM)
+        message(FATAL_ERROR "CONFIG_PLATFORM must be set when cross-compiling")
+    endif()
 endif()
 
-set(CMAKE_C_FLAGS
-        "${CMAKE_C_FLAGS} ${CC_WARN_FLAGS} ${CC_EXTRA_FLAGS}")
-set(CMAKE_CXX_FLAGS
-        "${CMAKE_CXX_FLAGS} ${CC_WARN_FLAGS} ${CXX_EXTRA_FLAGS}")
+message(STATUS "Platform will be used: ${CONFIG_PLATFORM}")
+
+set(PLATFORM_NAME ${CONFIG_PLATFORM}) # For convinience
 
 # Linker definitions is propagated by the platform.
 include(${CORE_DIR}/platform/common/linker.cmake)


### PR DESCRIPTION
Proper platform must be set by user if cross-compiling, or it should
defaulted to `host` if not.

Closes #136