### PR TITLE
SYSTMR implementation for TM4C

### DIFF
--- a/arch/arm_cm/CMakeLists.txt
+++ b/arch/arm_cm/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ARM Cortex-M architecture
-add_library(arch STATIC startup_arm_cm.S)
+add_library(arch STATIC startup_arm_cm.S arch.cpp)
 
 # By default CMake do not pass compile definitions to ASM files.
 # Probably due to the fact that it depends on assembler used and some of the

--- a/arch/arm_cm/arch.cpp
+++ b/arch/arm_cm/arch.cpp
@@ -1,0 +1,13 @@
+#include <stdint.h>
+
+extern "C"  void __attribute__((naked)) arch_delay(uint32_t loop_count)
+{
+    (void)loop_count;
+#if defined ( __GNUC__ )
+   __asm("    subs    r0, #1\n"
+          "    bne    arch_delay\n"
+          "    bx     lr");
+#else
+#error Not yet implemented for your compiler
+#endif
+}

--- a/arch/arm_cm/execution.cpp
+++ b/arch/arm_cm/execution.cpp
@@ -35,16 +35,4 @@ extern "C" void SysTick_Handler(void)
     systmr_handler();
 }
 
-extern "C"  void __attribute__((naked)) arch_delay(uint32_t loop_count)
-{
-    (void)loop_count;
-#if defined ( __GNUC__ )
-   __asm("    subs    r0, #1\n"
-          "    bne    arch_delay\n"
-          "    bx     lr");
-#else
-#error Not yet implemented for your compiler
-#endif
-}
-
 #endif // USE_SYSTMR

--- a/arch/arm_cm/execution.cpp
+++ b/arch/arm_cm/execution.cpp
@@ -4,11 +4,10 @@ namespace ecl
 {
 
 #if USE_SYSTMR
-
-static volatile uint32_t event_cnt;
-
 namespace systmr
 {
+
+static volatile uint32_t event_cnt;
 
 uint32_t events()
 {
@@ -32,7 +31,7 @@ extern "C" void systmr_handler(void)
 
 extern "C" void SysTick_Handler(void)
 {
-    ecl::event_cnt++;
+    ecl::systmr::event_cnt++;
     systmr_handler();
 }
 

--- a/arch/arm_cm/export/arch/execution.hpp
+++ b/arch/arm_cm/export/arch/execution.hpp
@@ -31,22 +31,6 @@ extern "C" void arch_delay(uint32_t loop_count);
 namespace ecl
 {
 
-//! \brief Gets core clock speed.
-//! \return Current clock speed.
-static inline uint32_t clk_spd()
-{
-    return SystemCoreClock;
-}
-
-//! \brief Gets current clock count.
-//! \details Uses DWT register.
-//! See http://www.carminenoviello.com/2015/09/04/precisely-measure-microseconds-stm32/
-//! \return Current clock count.
-static inline uint32_t clk()
-{
-    return DWT->CYCCNT;
-}
-
 //! \brief Aborts execution of currently running code. Never return.
 __attribute__((noreturn))
 static inline void abort()
@@ -138,7 +122,7 @@ static inline void arch_spin_wait(uint32_t ms)
     const short arch_delay_ticks = 3;
 
     // handle overflow
-    uint64_t ticks_left = (ecl::clk_spd() / 1000L / arch_delay_ticks) * ms;
+    uint64_t ticks_left = (SystemCoreClock / 1000L / arch_delay_ticks) * ms;
     while (UINT_MAX < ticks_left) {
         arch_delay(UINT_MAX);
         ticks_left -= UINT_MAX;

--- a/arch/arm_cm/export/arch/execution.hpp
+++ b/arch/arm_cm/export/arch/execution.hpp
@@ -83,8 +83,8 @@ namespace systmr
 static const uint32_t systmr_freq_min = 20;
 static const uint32_t systmr_freq_max = 1000;
 
-static_assert((THECORE_CONFIG_SYSTMR_FREQ > systmr_freq_min) &&
-               (THECORE_CONFIG_SYSTMR_FREQ < systmr_freq_max),
+static_assert((THECORE_CONFIG_SYSTMR_FREQ >= systmr_freq_min) &&
+               (THECORE_CONFIG_SYSTMR_FREQ <= systmr_freq_max),
                "The value of the THECORE_CONFIG_SYSTMR_FREQ frequency is out of the range.");
 
  //! Enables timer, start counting

--- a/platform/common/export/common/execution.hpp
+++ b/platform/common/export/common/execution.hpp
@@ -70,7 +70,7 @@ static inline bool wait_for(uint32_t ms, Predicate pred)
     }
 
     ecl::systmr::disable();
-#elif defined THECORE_PLATFORM_STUB_DEFINE_SPIN_WAIT // spin_wait exists. Hack till #247
+#else
     // Amount of millisecond to spin in one step.
     // Predicate will be checked once per quant.
     // No rational reasoning behind this value.
@@ -82,18 +82,6 @@ static inline bool wait_for(uint32_t ms, Predicate pred)
         } else {
             spin_wait(delay_quant);
             ms = ms > delay_quant ? ms - delay_quant : 0;
-        }
-    }
-
-#else // No system timer
-    uint32_t start = ecl::clk();
-    uint32_t to_wait = ms * (ecl::clk_spd() / 1000L);
-
-    while (1) {
-        if (pred()) { // Make sure that predicate is called at least once.
-            return true;
-        } else if (ecl::clk() - start >= to_wait) { // Handles wraparound.
-            break;
         }
     }
 #endif // USE_SYSTMR

--- a/platform/host/export/platform/execution.hpp
+++ b/platform/host/export/platform/execution.hpp
@@ -7,6 +7,8 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <time.h>
+#include <thread>
+#include <chrono>
 
 namespace ecl
 {
@@ -17,20 +19,15 @@ static inline void abort()
     abort();
 }
 
-//! \brief Gets core clock speed.
-//! \return Current clock speed. Unreliable on host platform.
-static inline uint64_t clk_spd()
+//! \brief Performs a dummy busy wait for specified amount of milliseconds.
+//! \param ms number of milliseconds to wait.
+//!
+//! This function is useful for a short delays.
+//!
+//! \return None.
+static inline void spin_wait(unsigned ms)
 {
-    return 1000; // Pretend that there is a 1 kHz clock.
-}
-
-//! \brief Gets current clock count.
-//! \return Current clock count.
-static inline uint64_t clk()
-{
-    // Host platform is unreliable in terms of clock speed, so just return
-    // seconds since epoch here. See also ecl::clk_spd()
-    return time(NULL) * 1000;
+    std::this_thread::sleep_for(std::chrono::milliseconds(ms));
 }
 
 } // namespace ecl

--- a/platform/particle_electron/export/platform/execution.hpp
+++ b/platform/particle_electron/export/platform/execution.hpp
@@ -11,10 +11,6 @@
 namespace ecl
 {
 
-//! Temporary define that notifies system that delay routine is present
-//! Will stay here before #247 will be implemented
-#define THECORE_PLATFORM_STUB_DEFINE_SPIN_WAIT
-
 //! Waits not less than given amount of milliseconds.
 static inline void spin_wait(unsigned ms)
 {

--- a/platform/stm32/export/platform/execution.hpp
+++ b/platform/stm32/export/platform/execution.hpp
@@ -8,6 +8,21 @@
 #include <stm32_device.hpp>
 #include <arch/execution.hpp>
 
+namespace ecl
+{
+//! \brief Performs a dummy busy wait for specified amount of milliseconds.
+//! \param ms number of milliseconds to wait.
+//!
+//! This function is useful for a short delays.
+//!
+//! \return None.
+static inline void spin_wait(uint32_t ms)
+{
+    ecl::arch_spin_wait(ms);
+}
+
+} //namespace ecl
+
 // TODO #213 add RTC support
 
 #endif // THE_CORE_EXECUTION_HPP_

--- a/platform/tm4c/CMakeLists.txt
+++ b/platform/tm4c/CMakeLists.txt
@@ -42,5 +42,22 @@ endif()
 # Platform is not CMSIS-compliant
 set(TARGET_PLATFORM_IS_NOT_CMSIS_COMPLIANT 1 CACHE BOOL "Compliance status" FORCE)
 
+# Represents default value for the THECORE_CONFIG_SYSTMR_FREQ (if SYSTMR is enabled)
+# The value of the THECORE_CONFIG_SYSTMR_FREQ must be in the range [20Hz, 1000Hz]
+set(THECORE_DEFAULT_SYSTMR_FREQ 50)
+
+# Use systick unless otherwise is explicitly stated
+if(NOT CONFIG_OS AND NOT DEFINED CONFIG_USE_SYSTMR_SYSTICK)
+    set(CONFIG_USE_SYSTMR_SYSTICK 1)
+endif()
+
+if(CONFIG_USE_SYSTMR_SYSTICK)
+    if (NOT THECORE_CONFIG_SYSTMR_FREQ)
+        set(THECORE_CONFIG_SYSTMR_FREQ ${THECORE_DEFAULT_SYSTMR_FREQ})
+    endif()
+
+    target_compile_definitions(tm4c PUBLIC -DUSE_SYSTMR=1 -DTHECORE_CONFIG_SYSTMR_FREQ=${THECORE_CONFIG_SYSTMR_FREQ})
+endif()
+
 # Platform provides its own implementation of WFI/WFE routines.
 target_compile_definitions(tm4c PUBLIC -DUSE_WFI_WFE=1)

--- a/platform/tm4c/export/platform/execution.hpp
+++ b/platform/tm4c/export/platform/execution.hpp
@@ -138,25 +138,8 @@ typedef struct
 
 //------------------------------------------------------------------------------
 
-extern "C" void systick_irq_handler(void);
-
 namespace ecl
 {
-
-//! \brief Gets core clock speed.
-//! \return Current clock speed.
-static inline uint32_t clk_spd()
-{
-    return SysCtlClockGet();
-}
-
-//! \brief Gets current clock count.
-//! \details Uses DWT register.
-//! \return Current clock count.
-static inline uint32_t clk()
-{
-    return DWT->CYCCNT;
-}
 
 //! \brief Aborts execution of currently running code. Never return.
 __attribute__((noreturn))
@@ -201,7 +184,7 @@ static_assert((THECORE_CONFIG_SYSTMR_FREQ >= systmr_freq_min) &&
  //! Enables timer, start counting
 static inline void enable()
 {
-    uint32_t reload_val = (1000 / THECORE_CONFIG_SYSTMR_FREQ) * clk_spd() / 1000;
+    uint32_t reload_val = (1000 / THECORE_CONFIG_SYSTMR_FREQ) * SysCtlClockGet() / 1000;
 
     SysTickPeriodSet(reload_val);
 
@@ -226,9 +209,9 @@ static inline void disable()
 //! \retval System timer events generation speed in Hz.
 static inline auto speed()
 {
-    uint32_t reload_val = (1000 / THECORE_CONFIG_SYSTMR_FREQ) * clk_spd() / 1000;
+    uint32_t reload_val = (1000 / THECORE_CONFIG_SYSTMR_FREQ) * SysCtlClockGet() / 1000;
 
-    return clk_spd() / reload_val;
+    return SysCtlClockGet() / reload_val;
 }
 
 //! Gets amount of events occurred so far.
@@ -251,7 +234,7 @@ static inline void spin_wait(uint32_t ms)
     const short SysCtlDelay_ticks = 3;
 
     // handle overflow
-    uint64_t ticks_left = (ecl::clk_spd() / 1000L / SysCtlDelay_ticks) * ms;
+    uint64_t ticks_left = (SysCtlClockGet() / 1000L / SysCtlDelay_ticks) * ms;
     while (UINT_MAX < ticks_left) {
         SysCtlDelay(UINT_MAX);
         ticks_left -= UINT_MAX;

--- a/platform/tm4c/platform.cpp
+++ b/platform/tm4c/platform.cpp
@@ -43,3 +43,42 @@ extern "C" void platform_init()
     ecl::bypass_console_init();
 #endif
 }
+
+
+namespace ecl
+{
+
+#if USE_SYSTMR
+
+namespace systmr
+{
+
+static volatile uint32_t event_cnt;
+
+uint32_t events()
+{
+    return event_cnt;
+}
+
+} // namespace systmr
+
+#endif // USE_SYSTMR
+
+} // namespace ecl
+
+#if USE_SYSTMR
+
+// User can override systimer handler to receive events on its side.
+extern "C" void systmr_handler(void) __attribute__((weak));
+
+extern "C" void systmr_handler(void)
+{
+}
+
+extern "C" void SysTick_Handler(void)
+{
+    ecl::systmr::event_cnt++;
+    systmr_handler();
+}
+
+#endif // USE_SYSTMR

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -155,7 +155,7 @@ add_suite(platform_bat
 #        TARGET_NAME         stm32f4discovery_simple)
 
 add_suite(platform_bat
-        CASES               bypass_console_bat
+        CASES               bypass_console_bat delay_bat
         TARGET_NAME         host)
 
 add_suite(platform_bat

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -136,13 +136,14 @@ endfunction()
 
 add_suite(platform_bat
         CASES               gpio_bat exti_manager_bat bypass_console_bat uart_bat
+                            systmr_bat delay_bat
         TOOLCHAIN_NAME      arm-cm4-gnu.cmake
         TARGET_NAME         tivac_tm4)
 
 # GNU suite
 add_suite(platform_bat
         CASES               systmr_bat uart_bat gpio_bat exti_manager_bat
-                            bypass_console_bat adc_bat
+                            bypass_console_bat adc_bat delay_bat
         TOOLCHAIN_NAME      arm-cm4-gnu.cmake
         TARGET_NAME         stm32f4discovery_simple)
 

--- a/tests/cases/delay_bat/case.cpp
+++ b/tests/cases/delay_bat/case.cpp
@@ -33,7 +33,7 @@ TEST(delay_bat, platform_spin_wait)
 
 TEST(delay_bat, common_wait_for)
 {
-    ("Wait for 100 ms");
+    UnityPrintWithEOL("Wait for 100 ms");
     ecl::wait_for(100);
 
     UnityPrintWithEOL("Wait for 2500 ms");


### PR DESCRIPTION
1) Implemented SYSTRM for TM4C platform
2) Implemented spin_wait() for STM32 and TM4C
3) Added delay_bat and systmr_bat to the TM4C on-board suite