### PR TITLE
Workaround broken GCC in Nix shell, when clang is used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ install:
     - travis_retry curl https://nixos.org/nix/install -o nix_install.sh
     - sh nix_install.sh
     - . $HOME/.nix-profile/etc/profile.d/nix.sh
-    - travis_retry nix-shell --pure --run true
+    - travis_retry nix-shell --pure --run true -j 2 --cores 2 -Q
 
 script: nix-shell --pure --run ./scripts/ci_test.sh

--- a/build_api.cmake
+++ b/build_api.cmake
@@ -42,7 +42,7 @@ function(msg_trace msg_body)
 endfunction(msg_trace)
 
 # Add test only if not cross-compiling
-if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL ${CMAKE_SYSTEM_NAME})
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL CMAKE_SYSTEM_NAME)
     find_package(CppUTest)
     if(NOT ${CPPUTEST_FOUND})
         msg_warn("CppUTest library not present. Tests are disabled.")

--- a/default.nix
+++ b/default.nix
@@ -9,6 +9,7 @@ let
 in with pkgs; {
   coreEnv = stdenv.mkDerivation {
     name = "thecore";
+    hardeningDisable = [ "all" ];
     buildInputs = [
       # With Python configuration requiring a special wrapper
       (python35.buildEnv.override {
@@ -23,7 +24,8 @@ in with pkgs; {
 
       which cmake gcc6 gdb cppcheck
       cpputest gcc-arm-embedded-5 dfu-util
-      doxygen clang openocd perlPackages.ArchiveZip xxd
+      doxygen  llvmPackages.clang-unwrapped openocd
+      perlPackages.ArchiveZip xxd
       fulltoc ];
 
     shellHook = ''


### PR DESCRIPTION
Issue described in NixOS/nixpkgs#29877

Also, remove unnecessary flags, as described in NixOS/nixpkgs#18995