### PR TITLE
Add string exploding utilities and reduced assertion size

### DIFF
--- a/dev/bus/tests/bus_unit.cpp
+++ b/dev/bus/tests/bus_unit.cpp
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "dev/bus.hpp"
+#include "mocks/platform_bus.hpp"
+
 #include <CppUTest/TestHarness.h>
 #include <CppUTest/CommandLineTestRunner.h>
 #include <CppUTestExt/MockSupport.h>
-
-#include "dev/bus.hpp"
-#include "mocks/platform_bus.hpp"
 
 // Our resident
 using bus_t = ecl::generic_bus< platform_mock >;

--- a/lib/cpp/tests/ostream_unit.cpp
+++ b/lib/cpp/tests/ostream_unit.cpp
@@ -2,14 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include <CppUTest/TestHarness.h>
-#include <CppUTest/CommandLineTestRunner.h>
-#include <CppUTestExt/MockSupport.h>
 #include <limits.h>
 #include <sstream>
 
 #include "ecl/ostream.hpp"
 #include "mock_device.hpp"
+
+#include <CppUTest/TestHarness.h>
+#include <CppUTest/CommandLineTestRunner.h>
+#include <CppUTestExt/MockSupport.h>
 
 using ostream_unit = ecl::ostream< mock_device >;
 

--- a/lib/utils/export/ecl/utils.hpp
+++ b/lib/utils/export/ecl/utils.hpp
@@ -102,6 +102,49 @@ constexpr auto extract_value(Enum val)
     return static_cast<std::underlying_type_t<Enum>>(val);
 }
 
+//------------------------------------------------------------------------------
+
+//! Exploded string produces unique type for every unique string
+template<char... c>
+struct exploded_string
+{
+    //! Exploded string static array
+    static const char fl[sizeof ...(c)];
+};
+
+template<char ...c>
+const char exploded_string<c...>::fl[sizeof ...(c)] = { c... };
+
+//! Explodes substring into `exploded_string` type.
+//! \tparam S String advertiser with str() method that will return valid
+//!           constexpr string.
+//! \tparam B Index of begin of substring to be exploded.
+//! \tparam L Length of substring to be exploded.
+template <typename S, size_t B, size_t L, char... c>
+struct explode_chunk_impl
+{
+    using result =
+    typename explode_chunk_impl<S, B, L - 1, S::str()[B + L - 1], c...>::result;
+};
+
+//! Explodes part of the string into `exploded_string` type.
+//! \tparam S String advertiser with str() method that will return valid
+//!           constexpr string.
+//! \tparam B Index of begin of substring to be exploded.
+template <typename S, size_t B, char... c >
+struct explode_chunk_impl<S, B, 0, c...>
+{
+    using result = exploded_string<c...>;
+};
+
+//! Syntactical sugar for exploding substring.
+//! \tparam S String advertiser with str() method that will return valid
+//!           constexpr string.
+//! \tparam B Index of begin of substring to be exploded.
+//! \tparam L Length of substring to be exploded.
+template <typename S, size_t B, size_t L>
+using explode_chunk = typename explode_chunk_impl<S, B, L>::result;
+
 } // namespace ecl
 
 #endif // LIB_ECL_UTILS_HPP_

--- a/lib/utils/version.in.cpp
+++ b/lib/utils/version.in.cpp
@@ -2,9 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#cmakedefine THECORE_VER4GIT_FOUND @THECORE_VER4GIT_FOUND@
+
 namespace ecl
 {
-#if @THECORE_VER4GIT_FOUND@
+#ifdef THECORE_VER4GIT_FOUND
 
 #if @PROJECT_GIT_DIRTY@
 #define DIRTY "-dirty"


### PR DESCRIPTION
For cpp files __FILE__ path is substituted with only filename in assertions.

Closes #327 