### PR TITLE
Use NVIC instead of IRQ manager for TM4C platform

### DIFF
--- a/arch/arm_cm/CMakeLists.txt
+++ b/arch/arm_cm/CMakeLists.txt
@@ -42,13 +42,13 @@ if(NOT TARGET_PLATFORM_IS_NOT_CMSIS_COMPLIANT)
             -DPLATFORM_CMSIS_COMPLIANT
             -DTHECORE_ENABLE_SYSTMR_API # Timer API is enabled in any case, even if not used by theCore.
             -DTHECORE_CONFIG_SYSTMR_FREQ=${THECORE_CONFIG_SYSTMR_FREQ}
-            -DUSE_WFI_WFE=1  # Architecture provides CMSIS-based WFI/WFE routines
+            -DTHECORE_USE_WFI_WFE=1  # Architecture provides CMSIS-based WFI/WFE routines
         )
     endif()
 
     target_compile_definitions(arch PUBLIC
             -DPLATFORM_CMSIS_COMPLIANT
-            -DUSE_WFI_WFE=1  # Architecture provides CMSIS-based WFI/WFE routines
+            -DTHECORE_USE_WFI_WFE=1  # Architecture provides CMSIS-based WFI/WFE routines
     )
 
     target_sources(arch PUBLIC ${CMAKE_CURRENT_LIST_DIR}/execution.cpp)

--- a/arch/arm_cm/startup_arm_cm.S
+++ b/arch/arm_cm/startup_arm_cm.S
@@ -89,10 +89,8 @@ __Vectors:
     .long	PendSV_Handler        /* PendSV Handler */
     .long	SysTick_Handler       /* SysTick Handler */
 
-    /* External interrupts */
-    .rept IRQ_COUNT /* Provided by the build system */
-    .long   core_isr
-    .endr
+    /* External interrupts, provided by the platform */
+#include "platform/irq.S"
 
     .size	__Vectors, . - __Vectors
 

--- a/lib/thread/no_os/semaphore.cpp
+++ b/lib/thread/no_os/semaphore.cpp
@@ -19,7 +19,7 @@ void ecl::semaphore::wait()
 
     if ((cnt = m_counter.fetch_sub(1)) <= 0) {
         while (m_counter.load() < cnt) {
-#ifdef USE_WFI_WFE
+#ifdef THECORE_USE_WFI_WFE
             ecl::wfe();
 #endif
         }
@@ -55,7 +55,7 @@ void ecl::binary_semaphore::signal()
 void ecl::binary_semaphore::wait()
 {
     while (!m_flag) {
-#ifdef USE_WFI_WFE
+#ifdef THECORE_USE_WFI_WFE
         ecl::wfe();
 #endif
     }

--- a/lib/thread/no_os/spinlock.cpp
+++ b/lib/thread/no_os/spinlock.cpp
@@ -13,7 +13,7 @@ constexpr ecl::spinlock::spinlock()
 void ecl::spinlock::lock()
 {
     while (m_flag.test_and_set(std::memory_order_acquire)) {
-#ifdef USE_WFI_WFE
+#ifdef THECORE_USE_WFI_WFE
         ecl::wfe();
 #endif
     }

--- a/platform/common/export/common/execution.hpp
+++ b/platform/common/export/common/execution.hpp
@@ -68,9 +68,9 @@ static inline bool wait_for(uint32_t ms, Predicate pred)
             break;
         }
 
-#ifdef USE_WFI_WFE
+#ifdef THECORE_USE_WFI_WFE
         ecl::wfe();
-#endif // USE_WFI_WFE
+#endif // THECORE_USE_WFI_WFE
     }
 
     ecl::systmr::disable();

--- a/platform/common/export/common/irq.hpp
+++ b/platform/common/export/common/irq.hpp
@@ -20,6 +20,8 @@ namespace ecl
 namespace irq
 {
 
+#if !defined THECORE_NO_IRQ_MANAGER || THECORE_NO_IRQ_MANAGER == 0
+
 using handler_type = std::function<void()>;
 
 //! Initializes storage for callbacks and setups default handler for every IRQ.
@@ -36,6 +38,8 @@ void subscribe(irq_num irqn, const irq::handler_type &handler);
 //! \param[in] irqn Valid IRQ number.
 //!
 void unsubscribe(irq_num irqn);
+
+#endif // !defined THECORE_NO_IRQ_MANAGER || THECORE_NO_IRQ_MANAGER == 0
 
 } // namespace ecl
 

--- a/platform/common/irq.cpp
+++ b/platform/common/irq.cpp
@@ -7,6 +7,9 @@
 
 #include "common/irq.hpp"
 
+#if !defined THECORE_NO_IRQ_MANAGER || THECORE_NO_IRQ_MANAGER == 0
+
+
 #include <ecl/assert.h>
 #include <platform/irq.hpp>
 #include <common/execution.hpp>
@@ -90,3 +93,5 @@ void unsubscribe(irq_num irqn)
 } // namespace irq
 
 } // namespace ecl
+
+#endif // !defined THECORE_NO_IRQ_MANAGER || THECORE_NO_IRQ_MANAGER == 0

--- a/platform/stm32/export/platform/irq.S
+++ b/platform/stm32/export/platform/irq.S
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.rept IRQ_COUNT /* Provided by the build system */
+.long   core_isr
+.endr

--- a/platform/tm4c/CMakeLists.txt
+++ b/platform/tm4c/CMakeLists.txt
@@ -6,7 +6,9 @@
 set(GEN_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated/)
 file(MAKE_DIRECTORY ${GEN_DIR}/export/aux)
 
-add_library(tm4c platform.cpp exti_manager.cpp ${GEN_DIR}/pin_mux.cpp)
+add_library(tm4c platform.cpp exti_manager.cpp
+    ${GEN_DIR}/pin_mux.cpp
+    ${GEN_DIR}/irq.cpp)
 
 include(mcu_cfg.cmake)
 
@@ -59,6 +61,9 @@ generate_source(gpio_cfg.in.hpp gpio_cfg.hpp)
 
 # Generate pins definitions
 generate_source(pin_mux.in.cpp pin_mux.cpp)
+
+# Generate IRQ handlers
+generate_source(irq.in.cpp irq.cpp)
 
 #-------------------------------------------------------------------------------
 

--- a/platform/tm4c/export/aux/uart_bus.hpp
+++ b/platform/tm4c/export/aux/uart_bus.hpp
@@ -102,6 +102,11 @@ public:
     uart_bus(const uart_bus&) = delete;
     uart_bus &operator=(uart_bus&) = delete;
 
+protected:
+    //! UART interrupt handler.
+    //! \details Receives interrupt from IRQ subsystem.
+    static void irq_bus_handler();
+
 private:
     //! Gets SYSCTL associated with given UART.
     static constexpr auto pick_sysctl();
@@ -112,8 +117,6 @@ private:
     //! Gets UART bus context.
     static constexpr auto &get_ctx();
 
-    //! UART interrupt handler.
-    static void irq_bus_handler();
 
     //! Stub handler, called in case if no one listens for bus events.
     static void stub_handler(bus_channel, bus_event, size_t)
@@ -322,7 +325,6 @@ err uart_bus<dev>::init()
                         UART_CONFIG_WLEN_8 | UART_CONFIG_STOP_ONE |
                         UART_CONFIG_PAR_NONE);
 
-    irq::subscribe(pick_it(), irq_bus_handler);
     UARTFIFODisable(periph);
 
     bus_ctx.status |= (ctx::inited | ctx::rx_done | ctx::tx_done);

--- a/platform/tm4c/export/platform/irq.S
+++ b/platform/tm4c/export/platform/irq.S
@@ -1,0 +1,143 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.long GPIOA_Handler /* 16 GPIO Port A */
+.long GPIOB_Handler /* 17 GPIO Port B */
+.long GPIOC_Handler /* 18 GPIO Port C */
+.long GPIOD_Handler /* 19 GPIO Port D */
+.long GPIOE_Handler /* 20 GPIO Port E */
+.long UART0_Handler /* 21 UART0 */
+.long UART1_Handler /* 22 UART1 */
+.long SSI0_Handler /* 23 SSI0 */
+.long I2C0_Handler /* 24 I2C0 */
+.long PWM0_FAULT_Handler /* 25 PWM0 Fault */
+.long PWM0_0_Handler /* 26 PWM0 Generator 0 */
+.long PWM0_1_Handler /* 27 PWM0 Generator 1 */
+.long PWM0_2_Handler /* 28 PWM0 Generator 2 */
+.long QEI0_Handler /* 29 QEI0 */
+.long ADC0SS0_Handler /* 30 ADC0 Sequence 0 */
+.long ADC0SS1_Handler /* 31 ADC0 Sequence 1 */
+.long ADC0SS2_Handler /* 32 ADC0 Sequence 2 */
+.long ADC0SS3_Handler /* 33 ADC0 Sequence 3 */
+.long WATCHDOG_Handler /* 34 Watchdog Timers 0 and 1 */
+.long TIMER0A_Handler /* 35 16/32-Bit Timer 0A */
+.long TIMER0B_Handler /* 36 16/32-Bit Timer 0B */
+.long TIMER1A_Handler /* 37 16/32-Bit Timer 1A */
+.long TIMER1B_Handler /* 38 16/32-Bit Timer 1B */
+.long TIMER2A_Handler /* 39 16/32-Bit Timer 2A */
+.long TIMER2B_Handler /* 40 16/32-Bit Timer 2B */
+.long COMP0_Handler /* 41 Analog Comparator 0 */
+.long COMP1_Handler /* 42 Analog Comparator 1 */
+.long 0 /* Reserved */
+.long SYSCTL_Handler /* 44 System Control */
+.long FLASH_Handler /* 45 Flash Memory Control and EEPROM */
+.long GPIOF_Handler /* 46 GPIO Port F */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long UART2_Handler /* 49 UART2 */
+.long SSI1_Handler /* 50 SSI1 */
+.long TIMER3A_Handler /* 51 16/32-Bit Timer 3A */
+.long TIMER3B_Handler /* 52 Timer 3B */
+.long I2C1_Handler /* 53 I2C1 */
+.long QEI1_Handler /* 54 QEI1 */
+.long CAN0_Handler /* 55 CAN0 */
+.long CAN1_Handler /* 56 CAN1 */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long HIBERNATE_Handler /* 59 Hibernation Module */
+.long USB0_Handler /* 60 USB */
+.long PWM0_3_Handler /* 61 PWM Generator 3 */
+.long UDMA_Handler /* 62 uDMA Software */
+.long UDMAERR_Handler /* 63 uDMA Error */
+.long ADC1SS0_Handler /* 64 ADC1 Sequence 0 */
+.long ADC1SS1_Handler /* 65 ADC1 Sequence 1 */
+.long ADC1SS2_Handler /* 66 ADC1 Sequence 2 */
+.long ADC1SS3_Handler /* 67 ADC1 Sequence 3 */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long SSI2_Handler /* 73 SSI2 */
+.long SSI3_Handler /* 74 SSI3 */
+.long UART3_Handler /* 75 UART3 */
+.long UART4_Handler /* 76 UART4 */
+.long UART5_Handler /* 77 UART5 */
+.long UART6_Handler /* 78 UART6 */
+.long UART7_Handler /* 79 UART7 */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long I2C2_Handler /* 84 I2C2 */
+.long I2C3_Handler /* 85 I2C3 */
+.long TIMER4A_Handler /* 86 16/32-Bit Timer 4A */
+.long TIMER4B_Handler /* 87 16/32-Bit Timer 4B */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long TIMER5A_Handler /* 108 16/32-Bit Timer 5A */
+.long TIMER5B_Handler /* 109 16/32-Bit Timer 5B */
+.long WTIMER0A_Handler /* 110 32/64-Bit Timer 0A */
+.long WTIMER0B_Handler /* 111 32/64-Bit Timer 0B */
+.long WTIMER1A_Handler /* 112 32/64-Bit Timer 1A */
+.long WTIMER1B_Handler /* 113 32/64-Bit Timer 1B */
+.long WTIMER2A_Handler /* 114 32/64-Bit Timer 2A */
+.long WTIMER2B_Handler /* 115 32/64-Bit Timer 2B */
+.long WTIMER3A_Handler /* 116 32/64-Bit Timer 3A */
+.long WTIMER3B_Handler /* 117 32/64-Bit Timer 3B */
+.long WTIMER4A_Handler /* 118 32/64-Bit Timer 4A */
+.long WTIMER4B_Handler /* 119 32/64-Bit Timer 4B */
+.long WTIMER5A_Handler /* 120 32/64-Bit Timer 5A */
+.long WTIMER5B_Handler /* 121 32/64-Bit Timer 5B */
+.long SYSEXC_Handler /* 122 System Exception (imprecise) */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long 0 /* Reserved */
+.long PWM1_0_Handler /* 150 PWM1 Generator 0 */
+.long PWM1_1_Handler /* 151 PWM1 Generator 1 */
+.long PWM1_2_Handler /* 152 PWM1 Generator 2 */
+.long PWM1_3_Handler /* 153 PWM1 Generator 3 */
+.long PWM1_FAULT_Handler /* 154 PWM1 Fault */

--- a/platform/tm4c/export/platform/irq.hpp
+++ b/platform/tm4c/export/platform/irq.hpp
@@ -18,7 +18,7 @@
 #define PLATFORM_IRQ_HPP_
 
 #include <platform/execution.hpp>
-
+#include <aux/platform_defines.hpp>
 #include <ecl/err.hpp>
 
 #include <functional>

--- a/platform/tm4c/platform.cpp
+++ b/platform/tm4c/platform.cpp
@@ -5,8 +5,6 @@
 #include <cstdint>
 #include <sysctl.h>
 
-#include <common/irq.hpp>
-
 #include "platform/exti_manager.hpp"
 
 #ifdef CORE_CONFIG_USE_BYPASS_CONSOLE
@@ -37,9 +35,6 @@ extern "C" void platform_init()
 {
     // TODO: implement
 
-    // IRQ must be ready before anything else will start work
-    ecl::irq::init_storage();
-
     // EXTI manager must be ready after IRQ, but before user code start working with it
     ecl::exti_manager::init();
 
@@ -47,8 +42,6 @@ extern "C" void platform_init()
     ecl::bypass_console_init();
 #endif
 }
-
-
 
 #if THECORE_ENABLE_SYSTMR_API
 

--- a/platform/tm4c/templates/defines.in.hpp
+++ b/platform/tm4c/templates/defines.in.hpp
@@ -51,8 +51,10 @@ if 'console' in cfg:
     //[[[end]]]
 #endif
 
-// WFI/WFE routines presense ---------------------------------------------------
-#define USE_WFI_WFE 1
+// WFI/WFE routines presense
+#define THECORE_USE_WFI_WFE 1
+// IRQ manager is not needed, interrupts are registered in compile-time
+#define THECORE_NO_IRQ_MANAGER 1
 
 
 #endif // TM4C_PLATFORM_DEFINES_

--- a/platform/tm4c/templates/irq.in.cpp
+++ b/platform/tm4c/templates/irq.in.cpp
@@ -6,6 +6,7 @@
 //! \brief TM4C IRQ handlers template.
 
 #include <platform/exti_manager.hpp>
+#include <platform/execution.hpp>
 
 /*[[[cog
 
@@ -16,18 +17,51 @@ f = open(JSON_CFG)
 cfg = json.load(f)
 cfg = cfg['platform']
 
+def_isr  = 'ecl::abort();'
+
+irqs = {
+    'uart': {
+        'ids': {
+            'UART0': def_isr,
+            'UART1': def_isr,
+        },
+        'header': 'aux/uart_cfg.hpp',
+        'isr_builder': (lambda id: 'ecl::uart_irq_proxy<ecl::uart_device::dev%s>::deliver_irq();' % id[-1])
+    }
+}
+
+# Extract exact periphery for which IRQs must be generated
+
+if 'uart' in cfg:
+    cog.outl('#include "{}"'.format(irqs['uart']['header']))
+    for uart in cfg['uart']:
+        id = uart['id']
+        if id in irqs['uart']['ids']:
+            irqs['uart']['ids'][id] = irqs['uart']['isr_builder'](id)
+
 ]]]*/
 //[[[end]]]
 
 namespace ecl
 {
 
-struct exti_event_receiver : public exti_manager
+//! EXTI interrupt proxy.
+struct exti_irq_proxy : public exti_manager
 {
     template<gpio_hw::port Port>
     static void deliver_irq()
     {
         irq_port_handler<Port>();
+    }
+};
+
+//! UART interrupt proxy.
+template<uart_device dev>
+struct uart_irq_proxy : uart_bus<dev>
+{
+    static void deliver_irq()
+    {
+        uart_bus<dev>::irq_bus_handler();
     }
 };
 
@@ -37,471 +71,554 @@ struct exti_event_receiver : public exti_manager
 extern "C"
 void GPIOA_Handler()
 {
-    ecl::exti_event_receiver::deliver_irq<ecl::gpio_hw::port::a>();
+    ecl::exti_irq_proxy::deliver_irq<ecl::gpio_hw::port::a>();
 }
 
 /* 17 GPIO Port B */
 extern "C"
 void GPIOB_Handler()
 {
-    ecl::exti_event_receiver::deliver_irq<ecl::gpio_hw::port::b>();
+    ecl::exti_irq_proxy::deliver_irq<ecl::gpio_hw::port::b>();
 }
 
 /* 18 GPIO Port C */
 extern "C"
 void GPIOC_Handler()
 {
-    ecl::exti_event_receiver::deliver_irq<ecl::gpio_hw::port::c>();
+    ecl::exti_irq_proxy::deliver_irq<ecl::gpio_hw::port::c>();
 }
 
 /* 19 GPIO Port D */
 extern "C"
 void GPIOD_Handler()
 {
-    ecl::exti_event_receiver::deliver_irq<ecl::gpio_hw::port::d>();
+    ecl::exti_irq_proxy::deliver_irq<ecl::gpio_hw::port::d>();
 }
 
 /* 20 GPIO Port E */
 extern "C"
 void GPIOE_Handler()
 {
-    ecl::exti_event_receiver::deliver_irq<ecl::gpio_hw::port::e>();
+    ecl::exti_irq_proxy::deliver_irq<ecl::gpio_hw::port::e>();
 }
 
 /* 21 UART0 */
 extern "C"
 void UART0_Handler()
 {
+    /*[[[cog
+
+    cog.outl(irqs['uart']['ids']['UART0'])
+
+    ]]]*/
+    //[[[end]]]
 }
 
 /* 22 UART1 */
 extern "C"
 void UART1_Handler()
 {
+    /*[[[cog
+
+    cog.outl(irqs['uart']['ids']['UART1'])
+
+    ]]]*/
+    //[[[end]]]
 }
 
 /* 23 SSI0 */
 extern "C"
 void SSI0_Handler()
 {
+    ecl::abort();
 }
 
 /* 24 I2C0 */
 extern "C"
 void I2C0_Handler()
 {
+    ecl::abort();
 }
 
 /* 25 PWM0 Fault */
 extern "C"
 void PWM0_FAULT_Handler()
 {
+    ecl::abort();
 }
 
 /* 26 PWM0 Generator 0 */
 extern "C"
 void PWM0_0_Handler()
 {
+    ecl::abort();
 }
 
 /* 27 PWM0 Generator 1 */
 extern "C"
 void PWM0_1_Handler()
 {
+    ecl::abort();
 }
 
 /* 28 PWM0 Generator 2 */
 extern "C"
 void PWM0_2_Handler()
 {
+    ecl::abort();
 }
 
 /* 29 QEI0 */
 extern "C"
 void QEI0_Handler()
 {
+    ecl::abort();
 }
 
 /* 30 ADC0 Sequence 0 */
 extern "C"
 void ADC0SS0_Handler()
 {
+    ecl::abort();
 }
 
 /* 31 ADC0 Sequence 1 */
 extern "C"
 void ADC0SS1_Handler()
 {
+    ecl::abort();
 }
 
 /* 32 ADC0 Sequence 2 */
 extern "C"
 void ADC0SS2_Handler()
 {
+    ecl::abort();
 }
 
 /* 33 ADC0 Sequence 3 */
 extern "C"
 void ADC0SS3_Handler()
 {
+    ecl::abort();
 }
 
 /* 34 Watchdog Timers 0 and 1 */
 extern "C"
 void WATCHDOG_Handler()
 {
+    ecl::abort();
 }
 
 /* 35 16/32-Bit Timer 0A */
 extern "C"
 void TIMER0A_Handler()
 {
+    ecl::abort();
 }
 
 /* 36 16/32-Bit Timer 0B */
 extern "C"
 void TIMER0B_Handler()
 {
+    ecl::abort();
 }
 
 /* 37 16/32-Bit Timer 1A */
 extern "C"
 void TIMER1A_Handler()
 {
+    ecl::abort();
 }
 
 /* 38 16/32-Bit Timer 1B */
 extern "C"
 void TIMER1B_Handler()
 {
+    ecl::abort();
 }
 
 /* 39 16/32-Bit Timer 2A */
 extern "C"
 void TIMER2A_Handler()
 {
+    ecl::abort();
 }
 
 /* 40 16/32-Bit Timer 2B */
 extern "C"
 void TIMER2B_Handler()
 {
+    ecl::abort();
 }
 
 /* 41 Analog Comparator 0 */
 extern "C"
 void COMP0_Handler()
 {
+    ecl::abort();
 }
 
 /* 42 Analog Comparator 1 */
 extern "C"
 void COMP1_Handler()
 {
+    ecl::abort();
 }
 
 /* 44 System Control */
 extern "C"
 void SYSCTL_Handler()
 {
+    ecl::abort();
 }
 
 /* 45 Flash Memory Control and EEPROM */
 extern "C"
 void FLASH_Handler()
 {
+    ecl::abort();
 }
 
 /* 46 GPIO Port F */
 extern "C"
 void GPIOF_Handler()
 {
+    ecl::abort();
 }
 
 /* 49 UART2 */
 extern "C"
 void UART2_Handler()
 {
+    ecl::abort();
 }
 
 /* 50 SSI1 */
 extern "C"
 void SSI1_Handler()
 {
+    ecl::abort();
 }
 
 /* 51 16/32-Bit Timer 3A */
 extern "C"
 void TIMER3A_Handler()
 {
+    ecl::abort();
 }
 
 /* 52 Timer 3B */
 extern "C"
 void TIMER3B_Handler()
 {
+    ecl::abort();
 }
 
 /* 53 I2C1 */
 extern "C"
 void I2C1_Handler()
 {
+    ecl::abort();
 }
 
 /* 54 QEI1 */
 extern "C"
 void QEI1_Handler()
 {
+    ecl::abort();
 }
 
 /* 55 CAN0 */
 extern "C"
 void CAN0_Handler()
 {
+    ecl::abort();
 }
 
 /* 56 CAN1 */
 extern "C"
 void CAN1_Handler()
 {
+    ecl::abort();
 }
 
 /* 59 Hibernation Module */
 extern "C"
 void HIBERNATE_Handler()
 {
+    ecl::abort();
 }
 
 /* 60 USB */
 extern "C"
 void USB0_Handler()
 {
+    ecl::abort();
 }
 
 /* 61 PWM Generator 3 */
 extern "C"
 void PWM0_3_Handler()
 {
+    ecl::abort();
 }
 
 /* 62 uDMA Software */
 extern "C"
 void UDMA_Handler()
 {
+    ecl::abort();
 }
 
 /* 63 uDMA Error */
 extern "C"
 void UDMAERR_Handler()
 {
+    ecl::abort();
 }
 
 /* 64 ADC1 Sequence 0 */
 extern "C"
 void ADC1SS0_Handler()
 {
+    ecl::abort();
 }
 
 /* 65 ADC1 Sequence 1 */
 extern "C"
 void ADC1SS1_Handler()
 {
+    ecl::abort();
 }
 
 /* 66 ADC1 Sequence 2 */
 extern "C"
 void ADC1SS2_Handler()
 {
+    ecl::abort();
 }
 
 /* 67 ADC1 Sequence 3 */
 extern "C"
 void ADC1SS3_Handler()
 {
+    ecl::abort();
 }
 
 /* 73 SSI2 */
 extern "C"
 void SSI2_Handler()
 {
+    ecl::abort();
 }
 
 /* 74 SSI3 */
 extern "C"
 void SSI3_Handler()
 {
+    ecl::abort();
 }
 
 /* 75 UART3 */
 extern "C"
 void UART3_Handler()
 {
+    ecl::abort();
 }
 
 /* 76 UART4 */
 extern "C"
 void UART4_Handler()
 {
+    ecl::abort();
 }
 
 /* 77 UART5 */
 extern "C"
 void UART5_Handler()
 {
+    ecl::abort();
 }
 
 /* 78 UART6 */
 extern "C"
 void UART6_Handler()
 {
+    ecl::abort();
 }
 
 /* 79 UART7 */
 extern "C"
 void UART7_Handler()
 {
+    ecl::abort();
 }
 
 /* 84 I2C2 */
 extern "C"
 void I2C2_Handler()
 {
+    ecl::abort();
 }
 
 /* 85 I2C3 */
 extern "C"
 void I2C3_Handler()
 {
+    ecl::abort();
 }
 
 /* 86 16/32-Bit Timer 4A */
 extern "C"
 void TIMER4A_Handler()
 {
+    ecl::abort();
 }
 
 /* 87 16/32-Bit Timer 4B */
 extern "C"
 void TIMER4B_Handler()
 {
+    ecl::abort();
 }
 
 /* 108 16/32-Bit Timer 5A */
 extern "C"
 void TIMER5A_Handler()
 {
+    ecl::abort();
 }
 
 /* 109 16/32-Bit Timer 5B */
 extern "C"
 void TIMER5B_Handler()
 {
+    ecl::abort();
 }
 
 /* 110 32/64-Bit Timer 0A */
 extern "C"
 void WTIMER0A_Handler()
 {
+    ecl::abort();
 }
 
 /* 111 32/64-Bit Timer 0B */
 extern "C"
 void WTIMER0B_Handler()
 {
+    ecl::abort();
 }
 
 /* 112 32/64-Bit Timer 1A */
 extern "C"
 void WTIMER1A_Handler()
 {
+    ecl::abort();
 }
 
 /* 113 32/64-Bit Timer 1B */
 extern "C"
 void WTIMER1B_Handler()
 {
+    ecl::abort();
 }
 
 /* 114 32/64-Bit Timer 2A */
 extern "C"
 void WTIMER2A_Handler()
 {
+    ecl::abort();
 }
 
 /* 115 32/64-Bit Timer 2B */
 extern "C"
 void WTIMER2B_Handler()
 {
+    ecl::abort();
 }
 
 /* 116 32/64-Bit Timer 3A */
 extern "C"
 void WTIMER3A_Handler()
 {
+    ecl::abort();
 }
 
 /* 117 32/64-Bit Timer 3B */
 extern "C"
 void WTIMER3B_Handler()
 {
+    ecl::abort();
 }
 
 /* 118 32/64-Bit Timer 4A */
 extern "C"
 void WTIMER4A_Handler()
 {
+    ecl::abort();
 }
 
 /* 119 32/64-Bit Timer 4B */
 extern "C"
 void WTIMER4B_Handler()
 {
+    ecl::abort();
 }
 
 /* 120 32/64-Bit Timer 5A */
 extern "C"
 void WTIMER5A_Handler()
 {
+    ecl::abort();
 }
 
 /* 121 32/64-Bit Timer 5B */
 extern "C"
 void WTIMER5B_Handler()
 {
+    ecl::abort();
 }
 
 /* 122 System Exception (imprecise) */
 extern "C"
 void SYSEXC_Handler()
 {
+    ecl::abort();
 }
 
 /* 150 PWM1 Generator 0 */
 extern "C"
 void PWM1_0_Handler()
 {
+    ecl::abort();
 }
 
 /* 151 PWM1 Generator 1 */
 extern "C"
 void PWM1_1_Handler()
 {
+    ecl::abort();
 }
 
 /* 152 PWM1 Generator 2 */
 extern "C"
 void PWM1_2_Handler()
 {
+    ecl::abort();
 }
 
 /* 153 PWM1 Generator 3 */
 extern "C"
 void PWM1_3_Handler()
 {
+    ecl::abort();
 }
 
 /* 154 PWM1 Fault */
 extern "C"
 void PWM1_FAULT_Handler()
 {
+    ecl::abort();
 }

--- a/platform/tm4c/templates/irq.in.cpp
+++ b/platform/tm4c/templates/irq.in.cpp
@@ -1,0 +1,507 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! \file
+//! \brief TM4C IRQ handlers template.
+
+#include <platform/exti_manager.hpp>
+
+/*[[[cog
+
+import cog
+import json
+
+f = open(JSON_CFG)
+cfg = json.load(f)
+cfg = cfg['platform']
+
+]]]*/
+//[[[end]]]
+
+namespace ecl
+{
+
+struct exti_event_receiver : public exti_manager
+{
+    template<gpio_hw::port Port>
+    static void deliver_irq()
+    {
+        irq_port_handler<Port>();
+    }
+};
+
+} // namespace ecl
+
+/* 16 GPIO Port A */
+extern "C"
+void GPIOA_Handler()
+{
+    ecl::exti_event_receiver::deliver_irq<ecl::gpio_hw::port::a>();
+}
+
+/* 17 GPIO Port B */
+extern "C"
+void GPIOB_Handler()
+{
+    ecl::exti_event_receiver::deliver_irq<ecl::gpio_hw::port::b>();
+}
+
+/* 18 GPIO Port C */
+extern "C"
+void GPIOC_Handler()
+{
+    ecl::exti_event_receiver::deliver_irq<ecl::gpio_hw::port::c>();
+}
+
+/* 19 GPIO Port D */
+extern "C"
+void GPIOD_Handler()
+{
+    ecl::exti_event_receiver::deliver_irq<ecl::gpio_hw::port::d>();
+}
+
+/* 20 GPIO Port E */
+extern "C"
+void GPIOE_Handler()
+{
+    ecl::exti_event_receiver::deliver_irq<ecl::gpio_hw::port::e>();
+}
+
+/* 21 UART0 */
+extern "C"
+void UART0_Handler()
+{
+}
+
+/* 22 UART1 */
+extern "C"
+void UART1_Handler()
+{
+}
+
+/* 23 SSI0 */
+extern "C"
+void SSI0_Handler()
+{
+}
+
+/* 24 I2C0 */
+extern "C"
+void I2C0_Handler()
+{
+}
+
+/* 25 PWM0 Fault */
+extern "C"
+void PWM0_FAULT_Handler()
+{
+}
+
+/* 26 PWM0 Generator 0 */
+extern "C"
+void PWM0_0_Handler()
+{
+}
+
+/* 27 PWM0 Generator 1 */
+extern "C"
+void PWM0_1_Handler()
+{
+}
+
+/* 28 PWM0 Generator 2 */
+extern "C"
+void PWM0_2_Handler()
+{
+}
+
+/* 29 QEI0 */
+extern "C"
+void QEI0_Handler()
+{
+}
+
+/* 30 ADC0 Sequence 0 */
+extern "C"
+void ADC0SS0_Handler()
+{
+}
+
+/* 31 ADC0 Sequence 1 */
+extern "C"
+void ADC0SS1_Handler()
+{
+}
+
+/* 32 ADC0 Sequence 2 */
+extern "C"
+void ADC0SS2_Handler()
+{
+}
+
+/* 33 ADC0 Sequence 3 */
+extern "C"
+void ADC0SS3_Handler()
+{
+}
+
+/* 34 Watchdog Timers 0 and 1 */
+extern "C"
+void WATCHDOG_Handler()
+{
+}
+
+/* 35 16/32-Bit Timer 0A */
+extern "C"
+void TIMER0A_Handler()
+{
+}
+
+/* 36 16/32-Bit Timer 0B */
+extern "C"
+void TIMER0B_Handler()
+{
+}
+
+/* 37 16/32-Bit Timer 1A */
+extern "C"
+void TIMER1A_Handler()
+{
+}
+
+/* 38 16/32-Bit Timer 1B */
+extern "C"
+void TIMER1B_Handler()
+{
+}
+
+/* 39 16/32-Bit Timer 2A */
+extern "C"
+void TIMER2A_Handler()
+{
+}
+
+/* 40 16/32-Bit Timer 2B */
+extern "C"
+void TIMER2B_Handler()
+{
+}
+
+/* 41 Analog Comparator 0 */
+extern "C"
+void COMP0_Handler()
+{
+}
+
+/* 42 Analog Comparator 1 */
+extern "C"
+void COMP1_Handler()
+{
+}
+
+/* 44 System Control */
+extern "C"
+void SYSCTL_Handler()
+{
+}
+
+/* 45 Flash Memory Control and EEPROM */
+extern "C"
+void FLASH_Handler()
+{
+}
+
+/* 46 GPIO Port F */
+extern "C"
+void GPIOF_Handler()
+{
+}
+
+/* 49 UART2 */
+extern "C"
+void UART2_Handler()
+{
+}
+
+/* 50 SSI1 */
+extern "C"
+void SSI1_Handler()
+{
+}
+
+/* 51 16/32-Bit Timer 3A */
+extern "C"
+void TIMER3A_Handler()
+{
+}
+
+/* 52 Timer 3B */
+extern "C"
+void TIMER3B_Handler()
+{
+}
+
+/* 53 I2C1 */
+extern "C"
+void I2C1_Handler()
+{
+}
+
+/* 54 QEI1 */
+extern "C"
+void QEI1_Handler()
+{
+}
+
+/* 55 CAN0 */
+extern "C"
+void CAN0_Handler()
+{
+}
+
+/* 56 CAN1 */
+extern "C"
+void CAN1_Handler()
+{
+}
+
+/* 59 Hibernation Module */
+extern "C"
+void HIBERNATE_Handler()
+{
+}
+
+/* 60 USB */
+extern "C"
+void USB0_Handler()
+{
+}
+
+/* 61 PWM Generator 3 */
+extern "C"
+void PWM0_3_Handler()
+{
+}
+
+/* 62 uDMA Software */
+extern "C"
+void UDMA_Handler()
+{
+}
+
+/* 63 uDMA Error */
+extern "C"
+void UDMAERR_Handler()
+{
+}
+
+/* 64 ADC1 Sequence 0 */
+extern "C"
+void ADC1SS0_Handler()
+{
+}
+
+/* 65 ADC1 Sequence 1 */
+extern "C"
+void ADC1SS1_Handler()
+{
+}
+
+/* 66 ADC1 Sequence 2 */
+extern "C"
+void ADC1SS2_Handler()
+{
+}
+
+/* 67 ADC1 Sequence 3 */
+extern "C"
+void ADC1SS3_Handler()
+{
+}
+
+/* 73 SSI2 */
+extern "C"
+void SSI2_Handler()
+{
+}
+
+/* 74 SSI3 */
+extern "C"
+void SSI3_Handler()
+{
+}
+
+/* 75 UART3 */
+extern "C"
+void UART3_Handler()
+{
+}
+
+/* 76 UART4 */
+extern "C"
+void UART4_Handler()
+{
+}
+
+/* 77 UART5 */
+extern "C"
+void UART5_Handler()
+{
+}
+
+/* 78 UART6 */
+extern "C"
+void UART6_Handler()
+{
+}
+
+/* 79 UART7 */
+extern "C"
+void UART7_Handler()
+{
+}
+
+/* 84 I2C2 */
+extern "C"
+void I2C2_Handler()
+{
+}
+
+/* 85 I2C3 */
+extern "C"
+void I2C3_Handler()
+{
+}
+
+/* 86 16/32-Bit Timer 4A */
+extern "C"
+void TIMER4A_Handler()
+{
+}
+
+/* 87 16/32-Bit Timer 4B */
+extern "C"
+void TIMER4B_Handler()
+{
+}
+
+/* 108 16/32-Bit Timer 5A */
+extern "C"
+void TIMER5A_Handler()
+{
+}
+
+/* 109 16/32-Bit Timer 5B */
+extern "C"
+void TIMER5B_Handler()
+{
+}
+
+/* 110 32/64-Bit Timer 0A */
+extern "C"
+void WTIMER0A_Handler()
+{
+}
+
+/* 111 32/64-Bit Timer 0B */
+extern "C"
+void WTIMER0B_Handler()
+{
+}
+
+/* 112 32/64-Bit Timer 1A */
+extern "C"
+void WTIMER1A_Handler()
+{
+}
+
+/* 113 32/64-Bit Timer 1B */
+extern "C"
+void WTIMER1B_Handler()
+{
+}
+
+/* 114 32/64-Bit Timer 2A */
+extern "C"
+void WTIMER2A_Handler()
+{
+}
+
+/* 115 32/64-Bit Timer 2B */
+extern "C"
+void WTIMER2B_Handler()
+{
+}
+
+/* 116 32/64-Bit Timer 3A */
+extern "C"
+void WTIMER3A_Handler()
+{
+}
+
+/* 117 32/64-Bit Timer 3B */
+extern "C"
+void WTIMER3B_Handler()
+{
+}
+
+/* 118 32/64-Bit Timer 4A */
+extern "C"
+void WTIMER4A_Handler()
+{
+}
+
+/* 119 32/64-Bit Timer 4B */
+extern "C"
+void WTIMER4B_Handler()
+{
+}
+
+/* 120 32/64-Bit Timer 5A */
+extern "C"
+void WTIMER5A_Handler()
+{
+}
+
+/* 121 32/64-Bit Timer 5B */
+extern "C"
+void WTIMER5B_Handler()
+{
+}
+
+/* 122 System Exception (imprecise) */
+extern "C"
+void SYSEXC_Handler()
+{
+}
+
+/* 150 PWM1 Generator 0 */
+extern "C"
+void PWM1_0_Handler()
+{
+}
+
+/* 151 PWM1 Generator 1 */
+extern "C"
+void PWM1_1_Handler()
+{
+}
+
+/* 152 PWM1 Generator 2 */
+extern "C"
+void PWM1_2_Handler()
+{
+}
+
+/* 153 PWM1 Generator 3 */
+extern "C"
+void PWM1_3_Handler()
+{
+}
+
+/* 154 PWM1 Fault */
+extern "C"
+void PWM1_FAULT_Handler()
+{
+}


### PR DESCRIPTION
First part of implementation for #227 . This PR covers TM4C platform only.