### PR TITLE
Extend example docs with OpenOCD commands and add FAQ

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -27,12 +27,13 @@ in with pkgs; with python35Packages; {
     hardeningDisable = [ "all" ];
     buildInputs = [
       cogapp jsonschema which cmake gcc6 gdb cppcheck git
-      cpputest gcc-arm-embedded-5 dfu-util
+      cpputest gcc-arm-embedded-5 dfu-util minicom
       llvmPackages.clang-unwrapped openocd
       perlPackages.ArchiveZip xxd cmake-version4git ] ++ docs_deps;
 
     shellHook = ''
         export GCC_ARM_EMBEDDED_PATH=${gcc-arm-embedded-5}
+        export TERM='linux'
     '';
   };
 }

--- a/doc/sphinx/source/contents.rst
+++ b/doc/sphinx/source/contents.rst
@@ -44,3 +44,4 @@ theCore: C++ Embedded Framework
   testing
   credits
   changelog
+  faq

--- a/doc/sphinx/source/examples/stm32f4-discovery-bluetooth-hm10.rst
+++ b/doc/sphinx/source/examples/stm32f4-discovery-bluetooth-hm10.rst
@@ -77,13 +77,8 @@ Running
 
 Firmware will be flashed via ``openocd`` and ``gdb``.
 
-#. Connect stm32f4 Discovery board to USB cable and connect USB <-> UART converter to the PC.
-#. Launch ``openocd`` using script from openocd installation.
-
-   ::
-
-     # From new terminal
-     openocd -f board/stm32f4discovery.cfg
+#. Connect stm32f4 Discovery board to USB cable and connect USB <-> UART
+   converter to the PC.
 
 #. Launch ``minicom`` with device associated with USB <-> UART converter.
    (``/dev/ttyUSB0`` here used as an example)::
@@ -91,33 +86,32 @@ Firmware will be flashed via ``openocd`` and ``gdb``.
      # From new terminal
      minicom -D /dev/ttyUSB0
 
-#. Provided that your main terminal's current directory is ``build``,
-   launch ``gdb``::
+#. Determine stm32f4discovery board revision.
 
-     # From the build directory
-     arm-none-eabi-gdb hm10_example
+   If you don't remember your board revision, check FAQ section
+   :ref:`theCore_STM32F4_Discovery_rev`.
 
-#. Under GDB shell, connect to ``openocd`` and flash firmware::
+#. Launch ``openocd`` and flash image using script from openocd installation.
 
-     (gdb) target remote :3333
-     Remote debugging using :3333
-     0x00000000 in ?? ()
+   For old STM32F407G-DISC boards, with STLINK/V2:
 
-     (gdb) monitor reset halt
-     target state: halted
-     target halted due to debug-request, current mode: Thread
-     xPSR: 0x01000000 pc: 0x08000188 msp: 0x20020000
+   ::
 
-     (gdb) load
-     Loading section .text, size 0x7678 lma 0x8000000
-     Loading section .data, size 0x3c lma 0x8007678
-     Start address 0x800477c, load size 30388
-     Transfer rate: 18 KB/sec, 10129 bytes/write.
+     sudo $(which openocd) -f board/stm32f4discovery.cfg -c 'init; reset halt; flash write_image erase hm10_example.bin 0x08000000; reset run; exit'
 
-#. Start new firmware::
+   For new STM32F407G-DISC1 boards, with STLINK/V2.1:
 
-     (gdb) continue
-     Continuing.
+   ::
+
+     sudo $(which openocd) -f board/stm32f429disc1.cfg -c 'init; reset halt; flash write_image erase hm10_example.bin 0x08000000; reset run; exit'
+
+   See :ref:`theCore_SudoOpenOCD_Nix` section to get insight why ``which openocd``
+   is important.
+
+   .. note::
+
+     Optionally, complete the :ref:`theCore_OpenOCD_NoRoot` guide, to be able
+     run OpenOCD without superuser permissions.
 
 #. Check ``minicom`` terminal. You should be able to see::
 

--- a/doc/sphinx/source/examples/stm32f4-discovery-cs43l22.rst
+++ b/doc/sphinx/source/examples/stm32f4-discovery-cs43l22.rst
@@ -47,14 +47,6 @@ Running
 Firmware will be flashed via ``openocd`` and ``gdb``.
 
 #. Connect stm32f4 Discovery board to USB cable and connect USB <-> UART converter to the PC.
-#. Launch ``openocd`` in the separate terminal using script provided by theCore.
-   Alternatively, you can use script from openocd installation.
-
-   ::
-
-     # From new terminal
-     cd path/to/theCore
-     openocd -f ./scripts/stm32f4discovery.cfg
 
 #. Launch ``minicom`` with device associated with USB <-> UART converter.
    (``/dev/ttyUSB0`` here used as an example)::
@@ -62,35 +54,32 @@ Firmware will be flashed via ``openocd`` and ``gdb``.
      # From new terminal
      minicom -D /dev/ttyUSB0
 
-#. Provided that your main terminal's current directory is ``build``,
-   launch ``gdb``::
+#. Determine stm32f4discovery board revision.
 
-     # From the build directory
-     arm-none-eabi-gdb audio
+   If you don't remember your board revision, check FAQ section
+   :ref:`theCore_STM32F4_Discovery_rev`.
 
-#. Under GDB shell, connect to ``openocd`` and flash firmware::
+#. Launch ``openocd`` and flash image using script from openocd installation.
 
-     (gdb) target remote :3333
-     Remote debugging using :3333
-     0x00000000 in ?? ()
+   For old STM32F407G-DISC boards, with STLINK/V2:
 
-     (gdb) monitor reset halt
-     target state: halted
-     target halted due to debug-request, current mode: Thread
-     xPSR: 0x01000000 pc: 0x08000188 msp: 0x20020000
+   ::
 
-     (gdb) load
-     Loading section .text, size 0x4724 lma 0x8000000
-     Loading section .init_array, size 0xc lma 0x8004724
-     Loading section .rodata, size 0x228 lma 0x8004730
-     Loading section .data, size 0x24 lma 0x8004958
-     Start address 0x8000188, load size 18812
-     Transfer rate: 14 KB/sec, 3762 bytes/write.
+     sudo $(which openocd) -f board/stm32f4discovery.cfg -c 'init; reset halt; flash write_image erase audio.bin 0x08000000; reset run; exit'
 
-#. Start new firmware::
+   For new STM32F407G-DISC1 boards, with STLINK/V2.1:
 
-     (gdb) continue
-     Continuing.
+   ::
+
+     sudo $(which openocd) -f board/stm32f429disc1.cfg -c 'init; reset halt; flash write_image erase audio.bin 0x08000000; reset run; exit'
+
+   See :ref:`theCore_SudoOpenOCD_Nix` section to get insight why ``which openocd``
+   is important.
+
+   .. note::
+
+     Optionally, complete the :ref:`theCore_OpenOCD_NoRoot` guide, to be able
+     run OpenOCD without superuser permissions.
 
 #. Attach headphones to the audio jack on Discovery board.
 

--- a/doc/sphinx/source/examples/stm32f4-discovery-exti.rst
+++ b/doc/sphinx/source/examples/stm32f4-discovery-exti.rst
@@ -62,14 +62,6 @@ Running
 Firmware will be flashed via ``openocd`` and ``gdb``.
 
 #. Connect stm32f4 Discovery board to USB cable and connect USB <-> UART converter to the PC.
-#. Launch ``openocd`` in the separate terminal using script provided by theCore.
-   Alternatively, you can use script from openocd installation.
-
-   ::
-
-     # From new terminal
-     cd path/to/theCore
-     openocd -f ./scripts/stm32f4discovery.cfg
 
 #. Launch ``minicom`` with device associated with USB <-> UART converter.
    (``/dev/ttyUSB0`` here used as an example)::
@@ -77,35 +69,32 @@ Firmware will be flashed via ``openocd`` and ``gdb``.
      # From new terminal
      minicom -D /dev/ttyUSB0
 
-#. Provided that your main terminal's current directory is ``build``,
-   launch ``gdb``::
+#. Determine stm32f4discovery board revision.
 
-     # From the build directory
-     arm-none-eabi-gdb exti
+   If you don't remember your board revision, check FAQ section
+   :ref:`theCore_STM32F4_Discovery_rev`.
 
-#. Under GDB shell, connect to ``openocd`` and flash firmware::
+#. Launch ``openocd`` and flash image using script from openocd installation.
 
-     (gdb) target remote :3333
-     Remote debugging using :3333
-     0x00000000 in ?? ()
+   For old STM32F407G-DISC boards, with STLINK/V2:
 
-     (gdb) monitor reset halt
-     target state: halted
-     target halted due to debug-request, current mode: Thread
-     xPSR: 0x01000000 pc: 0x08000188 msp: 0x20020000
+   ::
 
-     (gdb) load
-     Loading section .text, size 0x4724 lma 0x8000000
-     Loading section .init_array, size 0xc lma 0x8004724
-     Loading section .rodata, size 0x228 lma 0x8004730
-     Loading section .data, size 0x24 lma 0x8004958
-     Start address 0x8000188, load size 18812
-     Transfer rate: 14 KB/sec, 3762 bytes/write.
+     sudo $(which openocd) -f board/stm32f4discovery.cfg -c 'init; reset halt; flash write_image erase exti.bin 0x08000000; reset run; exit'
 
-#. Start new firmware::
+   For new STM32F407G-DISC1 boards, with STLINK/V2.1:
 
-     (gdb) continue
-     Continuing.
+   ::
+
+     sudo $(which openocd) -f board/stm32f429disc1.cfg -c 'init; reset halt; flash write_image erase exti.bin 0x08000000; reset run; exit'
+
+   See :ref:`theCore_SudoOpenOCD_Nix` section to get insight why ``which openocd``
+   is important.
+
+   .. note::
+
+     Optionally, complete the :ref:`theCore_OpenOCD_NoRoot` guide, to be able
+     run OpenOCD without superuser permissions.
 
 #. Press blue user button on the Discovery board and observe output in ``minicom``.
 

--- a/doc/sphinx/source/examples/stm32f4-discovery-htu21d-sensor.rst
+++ b/doc/sphinx/source/examples/stm32f4-discovery-htu21d-sensor.rst
@@ -57,14 +57,6 @@ Running
 Firmware will be flashed via ``openocd`` and ``gdb``.
 
 #. Connect stm32f4 Discovery board to USB cable and connect USB <-> UART converter to the PC.
-#. Launch ``openocd`` in the separate terminal using script provided by theCore.
-   Alternatively, you can use script from openocd installation.
-
-   ::
-
-     # From new terminal
-     cd path/to/theCore
-     openocd -f ./scripts/stm32f4discovery.cfg
 
 #. Launch ``minicom`` with device associated with USB <-> UART converter.
    (``/dev/ttyUSB0`` here used as an example)::
@@ -72,33 +64,32 @@ Firmware will be flashed via ``openocd`` and ``gdb``.
      # From new terminal
      minicom -D /dev/ttyUSB0
 
-#. Provided that your main terminal's current directory is ``build``,
-   launch ``gdb``::
+#. Determine stm32f4discovery board revision.
 
-     # From the build directory
-     arm-none-eabi-gdb htu21d_example
+   If you don't remember your board revision, check FAQ section
+   :ref:`theCore_STM32F4_Discovery_rev`.
 
-#. Under GDB shell, connect to ``openocd`` and flash firmware::
+#. Launch ``openocd`` and flash image using script from openocd installation.
 
-     (gdb) target remote :3333
-     Remote debugging using :3333
-     0x00000000 in ?? ()
+   For old STM32F407G-DISC boards, with STLINK/V2:
 
-     (gdb) monitor reset halt
-     target state: halted
-     target halted due to debug-request, current mode: Thread
-     xPSR: 0x01000000 pc: 0x08000188 msp: 0x20020000
+   ::
 
-     (gdb) load
-     Loading section .text, size 0x7678 lma 0x8000000
-     Loading section .data, size 0x3c lma 0x8007678
-     Start address 0x800477c, load size 30388
-     Transfer rate: 18 KB/sec, 10129 bytes/write.
+     sudo $(which openocd) -f board/stm32f4discovery.cfg -c 'init; reset halt; flash write_image erase htu21d_example.bin 0x08000000; reset run; exit'
 
-#. Start new firmware::
+   For new STM32F407G-DISC1 boards, with STLINK/V2.1:
 
-     (gdb) continue
-     Continuing.
+   ::
+
+     sudo $(which openocd) -f board/stm32f429disc1.cfg -c 'init; reset halt; flash write_image erase htu21d_example.bin 0x08000000; reset run; exit'
+
+   See :ref:`theCore_SudoOpenOCD_Nix` section to get insight why ``which openocd``
+   is important.
+
+   .. note::
+
+     Optionally, complete the :ref:`theCore_OpenOCD_NoRoot` guide, to be able
+     run OpenOCD without superuser permissions.
 
 #. Watch console output.
 

--- a/doc/sphinx/source/faq.rst
+++ b/doc/sphinx/source/faq.rst
@@ -1,0 +1,118 @@
+Frequently Asked Questions
+==========================
+
+How to fix ``libusb_open() failed with LIBUSB_ERROR_ACCESS`` when running OpenOCD?
+----------------------------------------------------------------------------------
+
+If you seeing a log like this:
+
+.. code-block:: text
+   :emphasize-lines: 13
+
+   Open On-Chip Debugger 0.10.0
+   Licensed under GNU GPL v2
+   For bug reports, read
+     http://openocd.org/doc/doxygen/bugs.html
+   Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
+   adapter speed: 2000 kHz
+   adapter_nsrst_delay: 100
+   none separate
+   srst_only separate srst_nogate srst_open_drain connect_deassert_srst
+   Info : Unable to match requested speed 2000 kHz, using 1800 kHz
+   Info : Unable to match requested speed 2000 kHz, using 1800 kHz
+   Info : clock speed 1800 kHz
+   Error: libusb_open() failed with LIBUSB_ERROR_ACCESS
+   Error: open failed
+   in procedure 'init'
+   in procedure 'ocd_bouncer'
+
+Solution is to either re-run OpenOCD with ``sudo``, as described in
+:ref:`theCore_SudoOpenOCD_Nix` section, or configure ``udev`` to let OpenOCD connect
+without requiring root privileges, using :ref:`theCore_OpenOCD_NoRoot` guide.
+
+I get plain ``Error: open failed`` when running OpenOCD with my STM32F4 Discovery board. What should I do?
+----------------------------------------------------------------------------------------------------------
+
+Most likely, you are running wrong OpenOCD script. Log in that case may look
+like this:
+
+.. code-block:: text
+   :emphasize-lines: 14
+
+   $ openocd -f board/stm32f4discovery.cfg
+   Open On-Chip Debugger 0.9.0 (2018-01-24-01:05)
+   Licensed under GNU GPL v2
+   For bug reports, read
+   http://openocd.org/doc/doxygen/bugs.html
+   Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
+   adapter speed: 2000 kHz
+   adapter_nsrst_delay: 100
+   none separate
+   srst_only separate srst_nogate srst_open_drain connect_deassert_srst
+   Info : Unable to match requested speed 2000 kHz, using 1800 kHz
+   Info : Unable to match requested speed 2000 kHz, using 1800 kHz
+   Info : clock speed 1800 kHz
+   Error: open failed
+   in procedure 'init'
+   in procedure 'ocd_bouncer'
+
+Solution is to run appropriate OpenOCD script:
+
+#. Determine the board revision using :ref:`theCore_STM32F4_Discovery_rev` section.
+#. Run correct script.
+
+   For old STM32F407G boards, with STLINK/V2::
+
+     openocd -f board/stm32f4discovery.cfg
+
+   For new STM32F407G-DISC1 boards, with STLINK/V2.1::
+
+     openocd -f board/stm32f429disc1.cfg
+
+.. _theCore_SudoOpenOCD_Nix:
+
+How to run OpenOCD with root privileges under Nix shell?
+--------------------------------------------------------
+
+Nix modifies the ``PATH`` environment variable. But running ``sudo``,
+drops ``PATH`` environment variable, so you need a full path to
+executable, installed by Nix.
+
+Thus, instead of running::
+
+   sudo openocd [openocd_arguments]
+
+You should run::
+
+   sudo $(which openocd) [openocd_arguments]
+
+How to run arbitrary command with root privileges under Nix shell?
+------------------------------------------------------------------
+
+Approach is similar, as in :ref:`theCore_SudoOpenOCD_Nix` section.
+Suppose you want to run command called ``foo``, you need to execute::
+
+   sudo $(which foo) [foo_arguments]
+
+How to run OpenOCD without root privileges?
+-------------------------------------------
+
+Complete the :ref:`theCore_OpenOCD_NoRoot` guide.
+
+.. _theCore_STM32F4_Discovery_rev:
+
+How to check STM32F4 Discovery board revision?
+----------------------------------------------
+
+Run ``lsusb`` in your console.
+
+For old Discovery board with ST-LINK/V2, you should see::
+
+    Bus 002 Device 125: ID 0483:3748 STMicroelectronics ST-LINK/V2
+
+For new Discovery board with ST-LINK/V2-A (labeled as STM32F407G-DISC1)::
+
+    Bus 001 Device 002: ID 0483:374b STMicroelectronics ST-LINK/V2.1 (Nucleo-F103RB)
+
+
+

--- a/doc/sphinx/source/guides/getting-started.rst
+++ b/doc/sphinx/source/guides/getting-started.rst
@@ -67,7 +67,7 @@ Using Nix
 #. Run Nix shell to get all environment required::
 
      # Run from theCore directory
-     nix-shell --pure
+     nix-shell .
 
 Moving forward
 ~~~~~~~~~~~~~~

--- a/doc/sphinx/source/guides/index.rst
+++ b/doc/sphinx/source/guides/index.rst
@@ -17,3 +17,4 @@ programming skills with theCore.
   multiplatform
   without-nix
   thirdparty-cache
+  running-openocd-without-sudo

--- a/doc/sphinx/source/guides/running-openocd-without-sudo.rst
+++ b/doc/sphinx/source/guides/running-openocd-without-sudo.rst
@@ -4,7 +4,24 @@ Running OpenOCD without root privileges
 ---------------------------------------
 
 Accessing USB devices on Linux requires root privileges by default.
-To be able to run OpenOCD without root, execute following steps:
+To be able to run OpenOCD without root, execute following steps.
+
+NixOS Linux
+~~~~~~~~~~~
+
+Add following lines to your ``/etc/nixos/configuration.nix``:
+
+.. code-block:: nix
+
+  {
+    users.extraGroups.plugdev = { };
+    users.extraUsers.rasen.extraGroups = [ "plugdev" "dialout" ];
+
+    services.udev.packages = [ pkgs.openocd ];
+  }
+
+Other Linux distros
+~~~~~~~~~~~~~~~~~~~
 
 #. Add user to `plugdev` group::
 
@@ -137,4 +154,6 @@ To be able to run OpenOCD without root, execute following steps:
 # Restart ``udev``.
 
   * Ubuntu: ``sudo udevadm trigger``
+  * ArchLinux: ``sudo udevadm control --reload && sudo udevadm trigger``
+
 

--- a/doc/sphinx/source/guides/running-openocd-without-sudo.rst
+++ b/doc/sphinx/source/guides/running-openocd-without-sudo.rst
@@ -1,0 +1,140 @@
+.. _theCore_OpenOCD_NoRoot:
+
+Running OpenOCD without root privileges
+---------------------------------------
+
+Accessing USB devices on Linux requires root privileges by default.
+To be able to run OpenOCD without root, execute following steps:
+
+#. Add user to `plugdev` group::
+
+    sudo useradd -G plugdev $(whoami)
+
+
+#. Create file `/etc/udev/rules.d/99-openocd.rules` (you will require root
+   privileges to create this file) with following content::
+
+    # Copy this file to /etc/udev/rules.d/
+
+    ACTION!="add|change", GOTO="openocd_rules_end"
+    SUBSYSTEM!="usb|tty|hidraw", GOTO="openocd_rules_end"
+
+    # Please keep this list sorted by VID:PID
+
+    # opendous and estick
+    ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="204f", MODE="664", GROUP="plugdev"
+
+    # Original FT232/FT245 VID:PID
+    ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", MODE="664", GROUP="plugdev"
+
+    # Original FT2232 VID:PID
+    ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6010", MODE="664", GROUP="plugdev"
+
+    # Original FT4232 VID:PID
+    ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6011", MODE="664", GROUP="plugdev"
+
+    # Original FT232H VID:PID
+    ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6014", MODE="664", GROUP="plugdev"
+
+    # DISTORTEC JTAG-lock-pick Tiny 2
+    ATTRS{idVendor}=="0403", ATTRS{idProduct}=="8220", MODE="664", GROUP="plugdev"
+
+    # TUMPA, TUMPA Lite
+    ATTRS{idVendor}=="0403", ATTRS{idProduct}=="8a98", MODE="664", GROUP="plugdev"
+    ATTRS{idVendor}=="0403", ATTRS{idProduct}=="8a99", MODE="664", GROUP="plugdev"
+
+    # XDS100v2
+    ATTRS{idVendor}=="0403", ATTRS{idProduct}=="a6d0", MODE="664", GROUP="plugdev"
+
+    # Xverve Signalyzer Tool (DT-USB-ST), Signalyzer LITE (DT-USB-SLITE)
+    ATTRS{idVendor}=="0403", ATTRS{idProduct}=="bca0", MODE="664", GROUP="plugdev"
+    ATTRS{idVendor}=="0403", ATTRS{idProduct}=="bca1", MODE="664", GROUP="plugdev"
+
+    # TI/Luminary Stellaris Evaluation Board FTDI (several)
+    ATTRS{idVendor}=="0403", ATTRS{idProduct}=="bcd9", MODE="664", GROUP="plugdev"
+
+    # TI/Luminary Stellaris In-Circuit Debug Interface FTDI (ICDI) Board
+    ATTRS{idVendor}=="0403", ATTRS{idProduct}=="bcda", MODE="664", GROUP="plugdev"
+
+    # egnite Turtelizer 2
+    ATTRS{idVendor}=="0403", ATTRS{idProduct}=="bdc8", MODE="664", GROUP="plugdev"
+
+    # Section5 ICEbear
+    ATTRS{idVendor}=="0403", ATTRS{idProduct}=="c140", MODE="664", GROUP="plugdev"
+    ATTRS{idVendor}=="0403", ATTRS{idProduct}=="c141", MODE="664", GROUP="plugdev"
+
+    # Amontec JTAGkey and JTAGkey-tiny
+    ATTRS{idVendor}=="0403", ATTRS{idProduct}=="cff8", MODE="664", GROUP="plugdev"
+
+    # TI ICDI
+    ATTRS{idVendor}=="0451", ATTRS{idProduct}=="c32a", MODE="664", GROUP="plugdev"
+
+    # STLink v1
+    ATTRS{idVendor}=="0483", ATTRS{idProduct}=="3744", MODE="664", GROUP="plugdev"
+
+    # STLink v2
+    ATTRS{idVendor}=="0483", ATTRS{idProduct}=="3748", MODE="664", GROUP="plugdev"
+
+    # STLink v2-1
+    ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374b", MODE="664", GROUP="plugdev"
+
+    # Hilscher NXHX Boards
+    ATTRS{idVendor}=="0640", ATTRS{idProduct}=="0028", MODE="664", GROUP="plugdev"
+
+    # Hitex STR9-comStick
+    ATTRS{idVendor}=="0640", ATTRS{idProduct}=="002c", MODE="664", GROUP="plugdev"
+
+    # Hitex STM32-PerformanceStick
+    ATTRS{idVendor}=="0640", ATTRS{idProduct}=="002d", MODE="664", GROUP="plugdev"
+
+    # Amontec JTAGkey-HiSpeed
+    ATTRS{idVendor}=="0fbb", ATTRS{idProduct}=="1000", MODE="664", GROUP="plugdev"
+
+    # IAR J-Link USB
+    ATTRS{idVendor}=="1366", ATTRS{idProduct}=="0101", MODE="664", GROUP="plugdev"
+    ATTRS{idVendor}=="1366", ATTRS{idProduct}=="0102", MODE="664", GROUP="plugdev"
+    ATTRS{idVendor}=="1366", ATTRS{idProduct}=="0103", MODE="664", GROUP="plugdev"
+    ATTRS{idVendor}=="1366", ATTRS{idProduct}=="0104", MODE="664", GROUP="plugdev"
+
+    # J-Link-OB (onboard)
+    ATTRS{idVendor}=="1366", ATTRS{idProduct}=="0105", MODE="664", GROUP="plugdev"
+
+    # Raisonance RLink
+    ATTRS{idVendor}=="138e", ATTRS{idProduct}=="9000", MODE="664", GROUP="plugdev"
+
+    # Debug Board for Neo1973
+    ATTRS{idVendor}=="1457", ATTRS{idProduct}=="5118", MODE="664", GROUP="plugdev"
+
+    # Olimex ARM-USB-OCD
+    ATTRS{idVendor}=="15ba", ATTRS{idProduct}=="0003", MODE="664", GROUP="plugdev"
+
+    # Olimex ARM-USB-OCD-TINY
+    ATTRS{idVendor}=="15ba", ATTRS{idProduct}=="0004", MODE="664", GROUP="plugdev"
+
+    # Olimex ARM-JTAG-EW
+    ATTRS{idVendor}=="15ba", ATTRS{idProduct}=="001e", MODE="664", GROUP="plugdev"
+
+    # Olimex ARM-USB-OCD-TINY-H
+    ATTRS{idVendor}=="15ba", ATTRS{idProduct}=="002a", MODE="664", GROUP="plugdev"
+
+    # Olimex ARM-USB-OCD-H
+    ATTRS{idVendor}=="15ba", ATTRS{idProduct}=="002b", MODE="664", GROUP="plugdev"
+
+    # USBprog with OpenOCD firmware
+    ATTRS{idVendor}=="1781", ATTRS{idProduct}=="0c63", MODE="664", GROUP="plugdev"
+
+    # TI/Luminary Stellaris In-Circuit Debug Interface (ICDI) Board
+    ATTRS{idVendor}=="1cbe", ATTRS{idProduct}=="00fd", MODE="664", GROUP="plugdev"
+
+    # Marvell Sheevaplug
+    ATTRS{idVendor}=="9e88", ATTRS{idProduct}=="9e8f", MODE="664", GROUP="plugdev"
+
+    # CMSIS-DAP compatible adapters
+    ATTRS{product}=="*CMSIS-DAP*", MODE="664", GROUP="plugdev"
+
+    LABEL="openocd_rules_end"
+
+# Restart ``udev``.
+
+  * Ubuntu: ``sudo udevadm trigger``
+


### PR DESCRIPTION
According to the feedback from Manuel, the documentation is extended with FAQ and examples are clarified. 